### PR TITLE
Target .NET Standard 2.0 instead of netcoreapp2.0

### DIFF
--- a/FFmpeg.AutoGen.Core/FFmpeg.AutoGen.Core.csproj
+++ b/FFmpeg.AutoGen.Core/FFmpeg.AutoGen.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40;net45;net46</TargetFrameworks>
     <PackageId>FFmpeg.AutoGen</PackageId>
     <Version>3.3.3.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
.NET Standard 2.0 is an API specification which is implemented by multiple frameworks. For example, the latest version of .NET Core, .NET Framework and Mono all implement .NET Standard 2.0.

On the other hand, netcoreapp2.0 only targets .NET Core console applications.

This PR changes the target from netcoreapp2.0 to netstandard2.0 so that class libraries which target netstandard2.0 can also use FFmpeg.AutoGen.