### PR TITLE
Convert null delegates to IntPtr.Zero

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Writer.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Writer.cs
@@ -89,7 +89,7 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
             {
                 WriteLine($"public IntPtr Pointer;");
                 Write($"public static implicit operator {@delegate.Name}({@delegate.FunctionName} func) => ");
-                Write($"new {@delegate.Name} {{ Pointer = Marshal.GetFunctionPointerForDelegate(func) }};");
+                Write($"new {@delegate.Name} {{ Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) }};");
                 WriteLine();
             }
         }


### PR DESCRIPTION
You don't always need to specify a value for callbacks in ffmpeg. Allow callers to specify delegates which are `null`,  and convert them to `IntPtr.Zero`. 