### PR TITLE
Catch exceptions from GetDelegateForFunctionPointer.

### DIFF
--- a/FFmpeg.AutoGen/Native/FunctionLoader.cs
+++ b/FFmpeg.AutoGen/Native/FunctionLoader.cs
@@ -121,7 +121,21 @@ namespace FFmpeg.AutoGen
 #if NET45
             return (T)(object)Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
 #else
-            return Marshal.GetDelegateForFunctionPointer<T>(ptr);
+            try
+            {
+                return Marshal.GetDelegateForFunctionPointer<T>(ptr);
+            }
+            catch (MarshalDirectiveException)
+            {
+                if (throwOnError)
+                {
+                    throw;
+                }
+                else
+                {
+                    return null;
+                }
+            }
 #endif
         }
 


### PR DESCRIPTION
There was a flaw in #72: if `FunctionLoader.LoadFunctionDelegate<T>` fails for any of the functions, you'll end up with an exception in the static constructor of `FFmpeg` and the class becomes unusable.

This PR adds some exception handling so that if a function fails to load, you'll end up with an empty delegate for that function but function loading continues normally for all other functions.