### PR TITLE
[WIP] Add CLI options. SuppressUnmanagedCodeSecurity support. Various fixes.

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
@@ -18,6 +18,14 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
             HelpText = "The name of the class that contains the FFmpeg unmanaged method calls.")]
         public string ClassName { get; set; }
 
+        /// <summary>
+        /// See http://ybeernet.blogspot.ro/2011/03/techniques-of-calling-unmanaged-code.html.
+        /// </summary>
+        [Option('f', "SuppressUnmanagedCodeSecurity",
+            HelpText = "Add the [SuppressUnmanagedCodeSecurity] attribute to unmanaged method calls " +
+                       "(faster invocation).")]
+        public bool SuppressUnmanagedCodeSecurity { get; set; }
+
         [Option('i', "input", Required = false,
             HelpText = "The path to the directory that contains the FFmpeg header and binary files " +
                        "(must have the default structure).")]

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.IO;
+
+using CommandLine;
+
+namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
+{
+    /// <summary>
+    /// Command line options.
+    /// </summary>
+    public class CliOptions
+    {
+        [Option('n', "namespace", DefaultValue = "FFmpeg.AutoGen",
+            HelpText = "The namespace that will contain the generated symbols.")]
+        public string Namespace { get; set; }
+
+        [Option('c', "class", DefaultValue = "ffmpeg",
+            HelpText = "The name of the class that contains the FFmpeg unmanaged method calls.")]
+        public string ClassName { get; set; }
+
+        [Option('i', "input", Required = false,
+            HelpText = "The path to the directory that contains the FFmpeg header and binary files " +
+                       "(must have the default structure).")]
+        public string FFmpegDir { get; set; }
+
+        [Option('h', "headers", Required = false,
+            HelpText = "The path to the directory that contains the FFmpeg header files.")]
+        public string FFmpegIncludesDir { get; set; }
+
+        [Option('b', "bin", Required = false,
+            HelpText = "The path to the directory that contains the FFmpeg binaries.")]
+        public string FFmpegBinDir { get; set; }
+
+        [Option('o', "output", Required = false,
+            HelpText = "The path to the directory where to output the generated files.")]
+        public string OutputDir { get; set; }
+
+        [Option('v',
+            HelpText = "Print details during execution.")]
+        public bool Verbose { get; set; }
+
+        public static CliOptions ParseArgumentsStrict(string[] args)
+        {
+            var options = new CliOptions();
+            Parser.Default.ParseArgumentsStrict(args, options);
+            options.Normalize();
+            return options;
+        }
+
+        private void Normalize()
+        {
+            // Support for the original path setup
+            const string solutionDir = "../../../../";
+
+            if (string.IsNullOrWhiteSpace(FFmpegDir) &&
+                string.IsNullOrWhiteSpace(FFmpegIncludesDir) &&
+                string.IsNullOrWhiteSpace(FFmpegBinDir))
+            {
+                FFmpegDir = Path.Combine(solutionDir, "ffmpeg");
+            }
+
+            if (string.IsNullOrWhiteSpace(OutputDir))
+            {
+                OutputDir = Path.Combine(solutionDir, "FFmpeg.AutoGen/");
+            }
+
+            // If the FFmpegDir option is specified, it will take precedence
+            if (!string.IsNullOrWhiteSpace(FFmpegDir))
+            {
+                FFmpegIncludesDir = Path.Combine(FFmpegDir, "include");
+                FFmpegBinDir = Path.Combine(FFmpegDir, "bin/x64");
+                FFmpegDir = null;
+            }
+
+            // Fail if required options are not specified
+            if (string.IsNullOrWhiteSpace(FFmpegBinDir))
+            {
+                Console.WriteLine("The path to the directory that contains " +
+                                  "the FFmpeg binaries is missing (specify it using -b or --bin).");
+                Environment.Exit(1);
+            }
+
+            if (string.IsNullOrWhiteSpace(FFmpegIncludesDir))
+            {
+                Console.WriteLine("The path to the directory that contains " +
+                                  "the FFmpeg headers is missing (specify it using -h or --headers).");
+                Environment.Exit(1);
+            }
+
+            // Check paths exist
+            if (!Directory.Exists(FFmpegBinDir))
+            {
+                Console.WriteLine("The path to the directory that contains " +
+                                  "the FFmpeg binaries does not exist.");
+                Environment.Exit(1);
+            }
+
+            if (!Directory.Exists(FFmpegIncludesDir))
+            {
+                Console.WriteLine("The path to the directory that contains " +
+                                  "the FFmpeg headers does not exist.");
+                Environment.Exit(1);
+            }
+
+            if (!Directory.Exists(OutputDir))
+            {
+                Console.WriteLine("The output directory does not exist.");
+                Environment.Exit(1);
+            }
+
+            // Resolve paths
+            FFmpegIncludesDir = Path.GetFullPath(FFmpegIncludesDir);
+            FFmpegBinDir = Path.GetFullPath(FFmpegBinDir);
+            OutputDir = Path.GetFullPath(OutputDir);
+        }
+    }
+}

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Definitions/FunctionDefinition.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Definitions/FunctionDefinition.cs
@@ -7,6 +7,7 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator.Definitions
         public int LibraryVersion { get; set; }
         public FunctionParameter[] Parameters { get; set; }
         public bool IsObsolete { get; set; }
+        public bool SuppressUnmanagedCodeSecurity { get; set; }
         public string ObsoleteMessage { get; set; }
         public string Content { get; set; }
         public string Name { get; set; }

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
@@ -75,6 +75,9 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="CppSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CppSharp.0.8.14\lib\CppSharp.dll</HintPath>
     </Reference>
@@ -104,6 +107,7 @@
     <Compile Include="Definitions\FixedArrayDefinition.cs" />
     <Compile Include="Definitions\TypeDefinition.cs" />
     <Compile Include="Definitions\MacroDefinition.cs" />
+    <Compile Include="CliOptions.cs" />
     <Compile Include="Processors\MacroPostProcessor.cs" />
     <Compile Include="Processors\MacroProcessor.cs" />
     <Compile Include="Processors\FunctionProcessor.cs" />

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generator.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generator.cs
@@ -27,6 +27,8 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
         public string Namespace { get; set; }
         public string ClassName { get; set; }
 
+        public bool SuppressUnmanagedCodeSecurity { get; set; }
+
         public void Parse(params string[] sourceFiles)
         {
             _hasParsingErrors = false;
@@ -90,6 +92,8 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
                         .ToList()
                         .ForEach(x =>
                         {
+                            x.SuppressUnmanagedCodeSecurity = SuppressUnmanagedCodeSecurity;
+
                             writer.WriteFunction(x);
                             writer.WriteLine();
                         });
@@ -200,6 +204,7 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
                 var writer = new Writer(textWriter);
                 writer.WriteLine("using System;");
                 writer.WriteLine("using System.Runtime.InteropServices;");
+                if (SuppressUnmanagedCodeSecurity) writer.WriteLine("using System.Security;");
                 writer.WriteLine();
                 writer.WriteLine($"namespace {Namespace}");
                 using (writer.BeginBlock()) execute(_astProcessor.Units, writer);

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -26,7 +26,12 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
 
             FunctionExport[] exports = FunctionExportHelper.LoadFunctionExports(options.FFmpegBinDir).ToArray();
 
-            var astProcessor = new ASTProcessor { FunctionExportMap = exports.ToDictionary(x => x.Name) };
+            var astProcessor = new ASTProcessor
+            {
+                FunctionExportMap = exports
+                    .GroupBy(x => x.Name).Select(x => x.First())    // Eliminate duplicated names
+                    .ToDictionary(x => x.Name)
+            };
             astProcessor.IgnoreUnitNames.Add("__NSConstantString_tag");
             astProcessor.TypeAliases.Add("int64_t", typeof(long));
             astProcessor.WellKnownMaros.Add("FFERRTAG", typeof(int));

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -1,29 +1,32 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+
 using FFmpeg.AutoGen.CppSharpUnsafeGenerator.Processors;
 
 namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
 {
     internal class Program
     {
-        private const string SolutionDir = "../../../../";
-        private const string FfmpegDir = SolutionDir + "ffmpeg/";
-        private const string FfmpegBinDir = FfmpegDir + "bin/x64";
-        private const string FfmpegIncludeDir = FfmpegDir + "include";
-        private const string Namespace = "FFmpeg.AutoGen";
-        private const string OutputDir = SolutionDir + "FFmpeg.AutoGen/";
-        public static string ClassName = "ffmpeg";
-
-        private static readonly string[] IncludeDirs = { Path.GetFullPath(FfmpegIncludeDir) };
-        private static readonly string[] Defines = { "__STDC_CONSTANT_MACROS" };
-        private static readonly FunctionExport[] Exports = FunctionExportHelper.LoadFunctionExports(FfmpegBinDir).ToArray();
-
         private static void Main(string[] args)
         {
-            Console.WriteLine("Current directory: " + Environment.CurrentDirectory);
+            CliOptions options = CliOptions.ParseArgumentsStrict(args);
 
-            var astProcessor = new ASTProcessor { FunctionExportMap = Exports.ToDictionary(x => x.Name) };
+            if (options.Verbose)
+            {
+                Console.WriteLine("Working dir: " + Environment.CurrentDirectory);
+                Console.WriteLine("Output dir: " + options.OutputDir);
+                Console.WriteLine("FFmpeg headers dir: " + options.FFmpegIncludesDir);
+                Console.WriteLine("FFmpeg bin dir: " + options.FFmpegBinDir);
+                Console.WriteLine("Namespace name: " + options.Namespace);
+                Console.WriteLine("Class name: " + options.ClassName);
+            }
+
+            var defines = new[] {"__STDC_CONSTANT_MACROS"};
+
+            FunctionExport[] exports = FunctionExportHelper.LoadFunctionExports(options.FFmpegBinDir).ToArray();
+
+            var astProcessor = new ASTProcessor { FunctionExportMap = exports.ToDictionary(x => x.Name) };
             astProcessor.IgnoreUnitNames.Add("__NSConstantString_tag");
             astProcessor.TypeAliases.Add("int64_t", typeof(long));
             astProcessor.WellKnownMaros.Add("FFERRTAG", typeof(int));
@@ -34,11 +37,12 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
 
             var g = new Generator(astProcessor)
             {
-                IncludeDirs = IncludeDirs,
-                Defines = Defines,
-                Exports = Exports,
-                Namespace = Namespace,
-                ClassName = ClassName
+                IncludeDirs = new[] {options.FFmpegIncludesDir},
+                Defines = defines,
+                Exports = exports,
+                Namespace = options.Namespace,
+                ClassName = options.ClassName,
+                SuppressUnmanagedCodeSecurity = options.SuppressUnmanagedCodeSecurity
             };
 
             g.Parse("libavutil/avutil.h");
@@ -70,13 +74,13 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
 
             g.Parse("libavdevice/avdevice.h");
 
-            g.WriteMacros(OutputDir + "FFmpeg.macros.g.cs");
-            g.WriteEnums(OutputDir + "FFmpeg.enums.g.cs");
-            g.WriteDelegates(OutputDir + "FFmpeg.delegates.g.cs");
-            g.WriteArrays(OutputDir + "FFmpeg.arrays.g.cs");
-            g.WriteStructures(OutputDir + "FFmpeg.structs.g.cs");
-            g.WriteIncompleteStructures(OutputDir + "FFmpeg.structs.incomplete.g.cs");
-            g.WriteFunctions(OutputDir + "FFmpeg.functions.g.cs");
+            g.WriteMacros(Path.Combine(options.OutputDir, "FFmpeg.macros.g.cs"));
+            g.WriteEnums(Path.Combine(options.OutputDir, "FFmpeg.enums.g.cs"));
+            g.WriteDelegates(Path.Combine(options.OutputDir, "FFmpeg.delegates.g.cs"));
+            g.WriteArrays(Path.Combine(options.OutputDir, "FFmpeg.arrays.g.cs"));
+            g.WriteStructures(Path.Combine(options.OutputDir, "FFmpeg.structs.g.cs"));
+            g.WriteIncompleteStructures(Path.Combine(options.OutputDir, "FFmpeg.structs.incomplete.g.cs"));
+            g.WriteFunctions(Path.Combine(options.OutputDir, "FFmpeg.functions.g.cs"));
         }
     }
 }

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Writer.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Writer.cs
@@ -79,6 +79,7 @@ namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator
             var functionDelegateName = function.Name + "_delegate";
             var returnCommand = function.ReturnType.Name == "void" ? string.Empty : "return ";
 
+            if (function.SuppressUnmanagedCodeSecurity) WriteLine("[SuppressUnmanagedCodeSecurity]");
             WriteLine("[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]");
             WriteLine($"private delegate {function.ReturnType.Name} {functionDelegateName}({parameters});");
             Write($"private static {functionDelegateName} {functionPtrName} = ");

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/packages.config
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Baseclass.Contrib.Nuget.Output" version="2.3.0" targetFramework="net462" />
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net462" />
   <package id="CppSharp" version="0.8.14" targetFramework="net462" developmentDependency="true" />
   <package id="RCore.ClangMacroParser" version="0.0.0.3" targetFramework="net462" />
 </packages>

--- a/FFmpeg.AutoGen/FFmpeg.arrays.g.cs
+++ b/FFmpeg.AutoGen/FFmpeg.arrays.g.cs
@@ -12,8 +12,8 @@ namespace FFmpeg.AutoGen
         
         public short this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p = &this) { p->_[i] = value; } }
         }
         public short[] ToArray()
         {
@@ -33,8 +33,8 @@ namespace FFmpeg.AutoGen
         
         public byte* this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
         }
         public byte*[] ToArray()
         {
@@ -54,8 +54,8 @@ namespace FFmpeg.AutoGen
         
         public int this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array3* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array3* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array3* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array3* p = &this) { p->_[i] = value; } }
         }
         public int[] ToArray()
         {
@@ -75,8 +75,8 @@ namespace FFmpeg.AutoGen
         
         public AVComponentDescriptor this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (AVComponentDescriptor* p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (AVComponentDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (AVComponentDescriptor* p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (AVComponentDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
         }
         public AVComponentDescriptor[] ToArray()
         {
@@ -96,8 +96,8 @@ namespace FFmpeg.AutoGen
         
         public byte* this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
         }
         public byte*[] ToArray()
         {
@@ -117,8 +117,8 @@ namespace FFmpeg.AutoGen
         
         public int this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array4* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array4* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array4* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array4* p = &this) { p->_[i] = value; } }
         }
         public int[] ToArray()
         {
@@ -138,8 +138,8 @@ namespace FFmpeg.AutoGen
         
         public long this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (long_array4* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (long_array4* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (long_array4* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (long_array4* p = &this) { p->_[i] = value; } }
         }
         public long[] ToArray()
         {
@@ -159,8 +159,8 @@ namespace FFmpeg.AutoGen
         
         public int this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array5* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array5* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array5* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array5* p = &this) { p->_[i] = value; } }
         }
         public int[] ToArray()
         {
@@ -180,8 +180,8 @@ namespace FFmpeg.AutoGen
         
         public short_array2 this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (short_array2* p0 = &_0) { *(p0 + i) = value;  } }
         }
         public short_array2[] ToArray()
         {
@@ -201,8 +201,8 @@ namespace FFmpeg.AutoGen
         
         public AVBufferRef* this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (AVBufferRef** p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (AVBufferRef** p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (AVBufferRef** p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (AVBufferRef** p0 = &_0) { *(p0 + i) = value;  } }
         }
         public AVBufferRef*[] ToArray()
         {
@@ -222,8 +222,8 @@ namespace FFmpeg.AutoGen
         
         public byte this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array8* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array8* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array8* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array8* p = &this) { p->_[i] = value; } }
         }
         public byte[] ToArray()
         {
@@ -243,8 +243,8 @@ namespace FFmpeg.AutoGen
         
         public byte* this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte** p0 = &_0) { *(p0 + i) = value;  } }
         }
         public byte*[] ToArray()
         {
@@ -264,8 +264,8 @@ namespace FFmpeg.AutoGen
         
         public int this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array8* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (int_array8* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array8* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (int_array8* p = &this) { p->_[i] = value; } }
         }
         public int[] ToArray()
         {
@@ -285,8 +285,8 @@ namespace FFmpeg.AutoGen
         
         public ulong this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (ulong_array8* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (ulong_array8* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (ulong_array8* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (ulong_array8* p = &this) { p->_[i] = value; } }
         }
         public ulong[] ToArray()
         {
@@ -306,8 +306,8 @@ namespace FFmpeg.AutoGen
         
         public byte this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array17* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array17* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array17* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array17* p = &this) { p->_[i] = value; } }
         }
         public byte[] ToArray()
         {
@@ -327,8 +327,8 @@ namespace FFmpeg.AutoGen
         
         public long this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (long_array17* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (long_array17* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (long_array17* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (long_array17* p = &this) { p->_[i] = value; } }
         }
         public long[] ToArray()
         {
@@ -348,8 +348,8 @@ namespace FFmpeg.AutoGen
         
         public byte this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array32* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array32* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array32* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array32* p = &this) { p->_[i] = value; } }
         }
         public byte[] ToArray()
         {
@@ -369,8 +369,8 @@ namespace FFmpeg.AutoGen
         
         public double this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p = &this) { p->_[i] = value; } }
         }
         public double[] ToArray()
         {
@@ -390,8 +390,8 @@ namespace FFmpeg.AutoGen
         
         public double_array399 this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p0 = &_0) { return *(p0 + i); } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p0 = &_0) { *(p0 + i) = value;  } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p0 = &_0) { return *(p0 + i); } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (double_array399* p0 = &_0) { *(p0 + i) = value;  } }
         }
         public double_array399[] ToArray()
         {
@@ -411,8 +411,8 @@ namespace FFmpeg.AutoGen
         
         public byte this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array1024* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array1024* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array1024* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array1024* p = &this) { p->_[i] = value; } }
         }
         public byte[] ToArray()
         {
@@ -432,8 +432,8 @@ namespace FFmpeg.AutoGen
         
         public byte this[uint i]
         {
-            get { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array61440* p = &this) { return p->_[i]; } }
-            set { if (i > Size) throw new ArgumentOutOfRangeException(); fixed (byte_array61440* p = &this) { p->_[i] = value; } }
+            get { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array61440* p = &this) { return p->_[i]; } }
+            set { if (i >= Size) throw new ArgumentOutOfRangeException(); fixed (byte_array61440* p = &this) { p->_[i] = value; } }
         }
         public byte[] ToArray()
         {


### PR DESCRIPTION
# Not ready, let me know your thoughts on this

This PR includes the following:

**CLI Options**
Added support for [command line options](https://github.com/gsscoder/commandline) so that the generator can be used in a build pipeline to tweak the generated code. If no command line options are specified, it will use the same options as before (when CLI options were not available).

The following CLI options are supported:
```
> FFmpeg.AutoGen.CppSharpUnsafeGenerator.exe -h
FFmpeg.AutoGen 1.0.0.0
Copyright c Ruslan Balanukhin 2015

  -n, --namespace                        (Default: FFmpeg.AutoGen) The
                                         namespace that will contain the
                                         generated symbols.

  -c, --class                            (Default: ffmpeg) The name of the
                                         class that contains the FFmpeg
                                         unmanaged method calls.

  -f, --SuppressUnmanagedCodeSecurity    Add the
                                         [SuppressUnmanagedCodeSecurity]
                                         attribute to unmanaged method calls
                                         (faster invocation).

  -i, --input                            The path to the directory that
                                         contains the FFmpeg header and binary
                                         files (must have the default
                                         structure).

  -h, --headers                          The path to the directory that
                                         contains the FFmpeg header files.

  -b, --bin                              The path to the directory that
                                         contains the FFmpeg binaries.

  -o, --output                           The path to the directory where to
                                         output the generated files.

  -v                                     Print details during execution.
```

**SuppressUnmanagedCodeSecurity**
The addition of the `[SuppressUnmanagedCodeSecurity]` attribute to unmanaged code calls [can improve the invocation speeds](http://ybeernet.blogspot.ro/2011/03/techniques-of-calling-unmanaged-code.html) (with a security cost, of course). This might be required for speed critical scenarios.

**Exports with duplicate names in FFmpeg DLLs**
I came across DLLs for FFmpeg that had duplicate exports (especially from DLLs built by myself). Most of these duplicates have nothing to do with the symbols in the header files so they can safely be deduplicated.

**Regenerated the FFmpeg.AutoGen project**

## Known problems
- The `Namespace` option is no longer valid, since the classes under the `Native` folder are no longer generated