### PR TITLE
Updated function loader for linux NET45

### DIFF
--- a/FFmpeg.AutoGen/Native/FunctionLoader.cs
+++ b/FFmpeg.AutoGen/Native/FunctionLoader.cs
@@ -52,7 +52,19 @@ namespace FFmpeg.AutoGen.Native
         private static IntPtr GetFunctionPointer(IntPtr nativeLibraryHandle, string functionName)
         {
 #if NET45
-            return WindowsNativeMethods.GetProcAddress(nativeLibraryHandle, functionName);
+                switch (LibraryLoader.GetPlatformId())
+                {
+                case PlatformID.MacOSX:
+                        return MacNativeMethods.dlsym(nativeLibraryHandle, functionName);
+                case PlatformID.Unix:
+                        return LinuxNativeMethods.dlsym(nativeLibraryHandle, functionName);
+                case PlatformID.Win32NT:
+                    case PlatformID.Win32S:
+                    case PlatformID.Win32Windows:
+                        return WindowsNativeMethods.GetProcAddress(nativeLibraryHandle, functionName);
+                default:
+                        throw new PlatformNotSupportedException();
+                }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 return LinuxNativeMethods.dlsym(nativeLibraryHandle, functionName);


### PR DESCRIPTION
Was getting exception in linux because target was .net 4.6 so NET45 was using the windows function by default. Same as  https://github.com/Ruslan-B/FFmpeg.AutoGen/issues/109#