### PR TITLE
Hardware acceleration for decoding in example project

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/App.config
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/App.config
@@ -1,7 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
   </startup>
 </configuration>

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/App.config
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
 </configuration>

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FFmpeg.AutoGen.CppSharpUnsafeGenerator</RootNamespace>
     <AssemblyName>FFmpeg.AutoGen.CppSharpUnsafeGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FFmpeg.AutoGen.CppSharpUnsafeGenerator</RootNamespace>
     <AssemblyName>FFmpeg.AutoGen.CppSharpUnsafeGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>

--- a/FFmpeg.AutoGen.Example/Program.cs
+++ b/FFmpeg.AutoGen.Example/Program.cs
@@ -20,7 +20,7 @@ namespace FFmpeg.AutoGen.Example
             Console.WriteLine($"FFmpeg version info: {ffmpeg.av_version_info()}");
             
             SetupLogging();
-            TryConfigureHWDecoder(out var deviceType);
+            ConfigureHWDecoder(out var deviceType);
 
             Console.WriteLine("Decoding...");
             DecodeAllFramesToImages(deviceType);
@@ -29,12 +29,12 @@ namespace FFmpeg.AutoGen.Example
             EncodeImagesToH264();
         }
 
-        private static void TryConfigureHWDecoder(out AVHWDeviceType HWtype)
+        private static void ConfigureHWDecoder(out AVHWDeviceType HWtype)
         {
             HWtype = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
             Console.WriteLine("Use hardware acceleration for decoding?[n]");
             var key = Console.ReadLine();
-            var avalibeHWDecoders = new Dictionary<int, AVHWDeviceType>();
+            var availableHWDecoders = new Dictionary<int, AVHWDeviceType>();
             if (key == "y")
             {
                 Console.WriteLine("Select hardware decoder:");
@@ -43,20 +43,20 @@ namespace FFmpeg.AutoGen.Example
                 while ((type = ffmpeg.av_hwdevice_iterate_types(type)) != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
                 {
                     Console.WriteLine($"{++number}. {type}");
-                    avalibeHWDecoders.Add(number, type);
+                    availableHWDecoders.Add(number, type);
                 }
-                if (avalibeHWDecoders.Count == 0)
+                if (availableHWDecoders.Count == 0)
                 {
                     Console.WriteLine("Your system have no hardware decoders.");
                     HWtype = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
                     return;
                 }
-                int decoderNumber = avalibeHWDecoders.SingleOrDefault(t => t.Value == AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2).Key;
+                int decoderNumber = availableHWDecoders.SingleOrDefault(t => t.Value == AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2).Key;
                 if (decoderNumber == 0)
-                    decoderNumber = avalibeHWDecoders.First().Key;
+                    decoderNumber = availableHWDecoders.First().Key;
                 Console.WriteLine($"Selected [{decoderNumber}]");
                 int.TryParse(Console.ReadLine(),out var inputDecoderNumber);
-                avalibeHWDecoders.TryGetValue(inputDecoderNumber == 0 ? decoderNumber: inputDecoderNumber, out HWtype);
+                availableHWDecoders.TryGetValue(inputDecoderNumber == 0 ? decoderNumber: inputDecoderNumber, out HWtype);
             }
         }
 

--- a/FFmpeg.AutoGen.Example/Program.cs
+++ b/FFmpeg.AutoGen.Example/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -19,12 +20,44 @@ namespace FFmpeg.AutoGen.Example
             Console.WriteLine($"FFmpeg version info: {ffmpeg.av_version_info()}");
             
             SetupLogging();
+            TryConfigureHWDecoder(out var deviceType);
 
             Console.WriteLine("Decoding...");
-            DecodeAllFramesToImages();
+            DecodeAllFramesToImages(deviceType);
 
             Console.WriteLine("Encoding...");
             EncodeImagesToH264();
+        }
+
+        private static void TryConfigureHWDecoder(out AVHWDeviceType HWtype)
+        {
+            HWtype = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
+            Console.WriteLine("Use hardware acceleration for decoding?[n]");
+            var key = Console.ReadLine();
+            var avalibeHWDecoders = new Dictionary<int, AVHWDeviceType>();
+            if (key == "y")
+            {
+                Console.WriteLine("Select hardware decoder:");
+                var type = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
+                var number = 0;
+                while ((type = ffmpeg.av_hwdevice_iterate_types(type)) != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
+                {
+                    Console.WriteLine($"{++number}. {type}");
+                    avalibeHWDecoders.Add(number, type);
+                }
+                if (avalibeHWDecoders.Count == 0)
+                {
+                    Console.WriteLine("Your system have no hardware decoders.");
+                    HWtype = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
+                    return;
+                }
+                int decoderNumber = avalibeHWDecoders.SingleOrDefault(t => t.Value == AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2).Key;
+                if (decoderNumber == 0)
+                    decoderNumber = avalibeHWDecoders.First().Key;
+                Console.WriteLine($"Selected [{decoderNumber}]");
+                int.TryParse(Console.ReadLine(),out var inputDecoderNumber);
+                avalibeHWDecoders.TryGetValue(inputDecoderNumber == 0 ? decoderNumber: inputDecoderNumber, out HWtype);
+            }
         }
 
         private static unsafe void SetupLogging()
@@ -49,11 +82,11 @@ namespace FFmpeg.AutoGen.Example
             ffmpeg.av_log_set_callback(logCallback);
         }
 
-        private static unsafe void DecodeAllFramesToImages()
+        private static unsafe void DecodeAllFramesToImages(AVHWDeviceType HWDevice)
         {
             // decode all frames from url, please not it might local resorce, e.g. string url = "../../sample_mpeg4.mp4";
             var url = "http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"; // be advised this file holds 1440 frames
-            using (var vsd = new VideoStreamDecoder(url))
+            using (var vsd = new VideoStreamDecoder(url,HWDevice))
             {
                 Console.WriteLine($"codec name: {vsd.CodecName}");
 
@@ -61,7 +94,7 @@ namespace FFmpeg.AutoGen.Example
                 info.ToList().ForEach(x => Console.WriteLine($"{x.Key} = {x.Value}"));
 
                 var sourceSize = vsd.FrameSize;
-                var sourcePixelFormat = vsd.PixelFormat;
+                var sourcePixelFormat = HWDevice == AVHWDeviceType.AV_HWDEVICE_TYPE_NONE ? vsd.PixelFormat : GetHWPixelFormat(HWDevice);
                 var destinationSize = sourceSize;
                 var destinationPixelFormat = AVPixelFormat.AV_PIX_FMT_BGR24;
                 using (var vfc = new VideoFrameConverter(sourceSize, sourcePixelFormat, destinationSize, destinationPixelFormat))
@@ -78,6 +111,37 @@ namespace FFmpeg.AutoGen.Example
                         frameNumber++;
                     }
                 }
+            }
+        }
+
+        private static AVPixelFormat GetHWPixelFormat(AVHWDeviceType hWDevice)
+        {
+            switch (hWDevice)
+            {
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_NONE:
+                    return AVPixelFormat.AV_PIX_FMT_NONE;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_VDPAU:
+                    return AVPixelFormat.AV_PIX_FMT_VDPAU;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_CUDA:
+                    return AVPixelFormat.AV_PIX_FMT_CUDA;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_VAAPI:
+                    return AVPixelFormat.AV_PIX_FMT_VAAPI;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2:
+                    return AVPixelFormat.AV_PIX_FMT_NV12;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_QSV:
+                    return AVPixelFormat.AV_PIX_FMT_QSV;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_VIDEOTOOLBOX:
+                    return AVPixelFormat.AV_PIX_FMT_VIDEOTOOLBOX;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_D3D11VA:
+                    return AVPixelFormat.AV_PIX_FMT_NV12;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_DRM:
+                    return AVPixelFormat.AV_PIX_FMT_DRM_PRIME;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_OPENCL:
+                    return AVPixelFormat.AV_PIX_FMT_OPENCL;
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_MEDIACODEC:
+                    return AVPixelFormat.AV_PIX_FMT_MEDIACODEC;
+                default:
+                    return AVPixelFormat.AV_PIX_FMT_NONE;
             }
         }
 

--- a/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
+++ b/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
@@ -14,7 +14,6 @@ namespace FFmpeg.AutoGen.Example
         private readonly AVFrame* _pFrame;
         private readonly AVFrame* _receivedFrame;
         private readonly AVPacket* _pPacket;
-        private readonly AVCodecHWConfig* config;
 
         public VideoStreamDecoder(string url, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {
@@ -28,8 +27,6 @@ namespace FFmpeg.AutoGen.Example
             _pCodecContext = ffmpeg.avcodec_alloc_context3(codec);
             if (HWDeviceType != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
             {
-                config = ffmpeg.avcodec_get_hw_config(codec, 0);
-                if (config == null) throw new DriveNotFoundException("Cloud not create hw config");
                 ffmpeg.av_hwdevice_ctx_create(&_pCodecContext->hw_device_ctx, HWDeviceType, null, null, 0).ThrowExceptionIfError();
             }
             ffmpeg.avcodec_parameters_to_context(_pCodecContext, _pFormatContext->streams[_streamIndex]->codecpar).ThrowExceptionIfError();

--- a/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
+++ b/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace FFmpeg.AutoGen.Example
@@ -11,38 +12,30 @@ namespace FFmpeg.AutoGen.Example
         private readonly AVFormatContext* _pFormatContext;
         private readonly int _streamIndex;
         private readonly AVFrame* _pFrame;
+        private readonly AVFrame* _receivedFrame;
         private readonly AVPacket* _pPacket;
+        private readonly AVCodecHWConfig* config;
 
-        public VideoStreamDecoder(string url)
+        public VideoStreamDecoder(string url, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {
             _pFormatContext = ffmpeg.avformat_alloc_context();
-
+            _receivedFrame = ffmpeg.av_frame_alloc();
             var pFormatContext = _pFormatContext;
             ffmpeg.avformat_open_input(&pFormatContext, url, null, null).ThrowExceptionIfError();
-
             ffmpeg.avformat_find_stream_info(_pFormatContext, null).ThrowExceptionIfError();
-
-            // find the first video stream
-            AVStream* pStream = null;
-            for (var i = 0; i < _pFormatContext->nb_streams; i++)
-                if (_pFormatContext->streams[i]->codec->codec_type == AVMediaType.AVMEDIA_TYPE_VIDEO)
-                {
-                    pStream = _pFormatContext->streams[i];
-                    break;
-                }
-
-            if (pStream == null) throw new InvalidOperationException("Could not found video stream.");
-
-            _streamIndex = pStream->index;
-            _pCodecContext = pStream->codec;
-
-            var codecId = _pCodecContext->codec_id;
-            var pCodec = ffmpeg.avcodec_find_decoder(codecId);
-            if (pCodec == null) throw new InvalidOperationException("Unsupported codec.");
-
-            ffmpeg.avcodec_open2(_pCodecContext, pCodec, null).ThrowExceptionIfError();
-
-            CodecName = ffmpeg.avcodec_get_name(codecId);
+            AVCodec* codec = null;
+            _streamIndex = ffmpeg.av_find_best_stream(_pFormatContext, AVMediaType.AVMEDIA_TYPE_VIDEO, -1, -1, &codec, 0).ThrowExceptionIfError();
+            _pCodecContext = ffmpeg.avcodec_alloc_context3(codec);
+            if (HWDeviceType != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
+            {
+                config = ffmpeg.avcodec_get_hw_config(codec, 0);
+                if (config == null) throw new DriveNotFoundException("Cloud not create hw config");
+                ffmpeg.av_hwdevice_ctx_create(&_pCodecContext->hw_device_ctx, HWDeviceType, null, null, 0).ThrowExceptionIfError();
+            }
+            ffmpeg.avcodec_parameters_to_context(_pCodecContext, _pFormatContext->streams[_streamIndex]->codecpar).ThrowExceptionIfError();
+            ffmpeg.avcodec_open2(_pCodecContext, codec, null).ThrowExceptionIfError();
+            
+            CodecName = ffmpeg.avcodec_get_name(codec->id);
             FrameSize = new Size(_pCodecContext->width, _pCodecContext->height);
             PixelFormat = _pCodecContext->pix_fmt;
 
@@ -70,6 +63,7 @@ namespace FFmpeg.AutoGen.Example
         public bool TryDecodeNextFrame(out AVFrame frame)
         {
             ffmpeg.av_frame_unref(_pFrame);
+            ffmpeg.av_frame_unref(_receivedFrame);
             int error;
             do
             {
@@ -96,9 +90,16 @@ namespace FFmpeg.AutoGen.Example
 
                 error = ffmpeg.avcodec_receive_frame(_pCodecContext, _pFrame);
             } while (error == ffmpeg.AVERROR(ffmpeg.EAGAIN));
-
             error.ThrowExceptionIfError();
-            frame = *_pFrame;
+            if (_pCodecContext->hw_device_ctx != null)
+            {
+                ffmpeg.av_hwframe_transfer_data(_receivedFrame, _pFrame, 0).ThrowExceptionIfError();
+                frame = *_receivedFrame;
+            }
+            else
+            {
+                frame = *_pFrame;
+            }
             return true;
         }
 


### PR DESCRIPTION
Added feature to select hardware acceleration when decoding video in the example.
Tested with DXVA2 and D3D11VA. 