### PR TITLE
Fix a memleak in example / refine CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,3 @@ jobs:
       - name: Build Example
         run: |
           dotnet build -c Release FFmpeg.AutoGen.Example
-      - name: Build Generator
-        if: matrix.os == 'windows-latest'
-        run: |
-          dotnet build -c Release FFmpeg.AutoGen.CppSharpUnsafeGenerator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Build Library
@@ -19,3 +20,10 @@ jobs:
       - name: Build Example
         run: |
           dotnet build -c Release FFmpeg.AutoGen.Example
+      - uses: actions/upload-artifact@v2
+        with:
+          path: FFmpeg.AutoGen/bin/Release/*.nupkg
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          path: FFmpeg.AutoGen/bin/Release/*.snupkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: main
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Library
+        run: |
+          dotnet build -c Release FFmpeg.AutoGen
+      - name: Build Example
+        run: |
+          dotnet build -c Release FFmpeg.AutoGen.Example
+      - name: Build Generator
+        if: matrix.os == 'windows-latest'
+        run: |
+          dotnet build -c Release FFmpeg.AutoGen.CppSharpUnsafeGenerator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,11 @@ jobs:
         run: |
           dotnet build -c Release FFmpeg.AutoGen.Example
       - uses: actions/upload-artifact@v2
+        if: matrix.os == 'windows-latest'
         with:
           path: FFmpeg.AutoGen/bin/Release/*.nupkg
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
+        if: matrix.os == 'windows-latest'
         with:
           path: FFmpeg.AutoGen/bin/Release/*.snupkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: csharp
 mono: none
 dotnet: 5.0.200
 script:
-  - dotnet restore
-  - dotnet build ./FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj
+  - dotnet build -c Release ./FFmpeg.AutoGen
+  - dotnet build -c Release ./FFmpeg.AutoGen.Example

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: csharp
 mono: none
-dotnet: 2.0.0
+dotnet: 5.0.200
 script:
   - dotnet restore
   - dotnet build ./FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj

--- a/FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj
+++ b/FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
+++ b/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
@@ -7,19 +7,30 @@ namespace FFmpeg.AutoGen.Example
     {
         internal static void RegisterFFmpegBinaries()
         {
-            var current = Environment.CurrentDirectory;
-            var probe = Path.Combine("FFmpeg", "bin", Environment.Is64BitProcess ? "x64" : "x86");
-            while (current != null)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var ffmpegBinaryPath = Path.Combine(current, probe);
-                if (Directory.Exists(ffmpegBinaryPath))
+                var current = Environment.CurrentDirectory;
+                var probe = Path.Combine("FFmpeg", "bin", Environment.Is64BitProcess ? "x64" : "x86");
+                while (current != null)
                 {
-                    Console.WriteLine($"FFmpeg binaries found in: {ffmpegBinaryPath}");
-                    ffmpeg.RootPath = ffmpegBinaryPath;
-                    return;
-                }
+                    var ffmpegBinaryPath = Path.Combine(current, probe);
+                    if (Directory.Exists(ffmpegBinaryPath))
+                    {
+                        Console.WriteLine($"FFmpeg binaries found in: {ffmpegBinaryPath}");
+                        ffmpeg.RootPath = ffmpegBinaryPath;
+                        return;
+                    }
 
-                current = Directory.GetParent(current)?.FullName;
+                    current = Directory.GetParent(current)?.FullName;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ffmpeg.RootPath = "/lib/x86_64-linux-gnu/";
+            }
+            else
+            {
+                // TODO
             }
         }
     }

--- a/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
+++ b/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace FFmpeg.AutoGen.Example
 {

--- a/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
+++ b/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
@@ -68,6 +68,7 @@ namespace FFmpeg.AutoGen.Example
                 {
                     do
                     {
+                        ffmpeg.av_packet_unref(_pPacket);
                         error = ffmpeg.av_read_frame(_pFormatContext, _pPacket);
                         if (error == ffmpeg.AVERROR_EOF)
                         {

--- a/FFmpeg.AutoGen/FFmpeg.cs
+++ b/FFmpeg.AutoGen/FFmpeg.cs
@@ -75,7 +75,7 @@ namespace FFmpeg.AutoGen
                 else if (throwException)
                 {
                     throw new DllNotFoundException(
-                        $"Unable to load DLL '{libraryName}.{version}': The specified module could not be found.");
+                        $"Unable to load DLL '{libraryName}.{version} under {RootPath}': The specified module could not be found.");
                 }
 
                 return ptr;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Please consider to ask *how to* questions on [stackoverflow.com](https://stackov
 The community may be able to offer some assistance but you will largely be on your own.
 As another option you can search for a solution in C(lang) as with some effort you can convert it to C#.**
 
-## FFmpeg.AutoGen [![Build Status](https://travis-ci.org/Ruslan-B/FFmpeg.AutoGen.svg)](https://travis-ci.org/Ruslan-B/FFmpeg.AutoGen)[![#](https://img.shields.io/nuget/v/FFmpeg.AutoGen.svg)](https://www.nuget.org/packages/FFmpeg.AutoGen/)
+## FFmpeg.AutoGen 
+[![main](https://github.com/Ruslan-B/FFmpeg.AutoGen/actions/workflows/main.yml/badge.svg)](https://github.com/Ruslan-B/FFmpeg.AutoGen/actions/workflows/main.yml)
+[![travis](https://travis-ci.org/Ruslan-B/FFmpeg.AutoGen.svg)](https://travis-ci.org/Ruslan-B/FFmpeg.AutoGen)
+[![nuget](https://img.shields.io/nuget/v/FFmpeg.AutoGen.svg)](https://www.nuget.org/packages/FFmpeg.AutoGen/)
 
 FFmpeg auto generated unsafe bindings for C#/.NET and Mono.
 


### PR DESCRIPTION
https://github.com/Ruslan-B/FFmpeg.AutoGen/issues/151 
The fix can be verified on linux using valgrind. Please let me know your concerns, thanks!
```
valgrind --leak-check=full --show-leak-kinds=definite  -- ./FFmpeg.AutoGen.Example
```

The CI build was successful in [my fork](https://github.com/hanabi1224/FFmpeg.AutoGen/actions/runs/646517342), with nuget package uploaded to artifacts