### PR TITLE
Create a FFmpeg redist package (for win-x64)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Build Example
         run: |
           dotnet build -c Release FFmpeg.AutoGen.Example
+      - name: Build Redist windows x64
+        if: matrix.os == 'windows-latest'
+        run: |
+          dotnet build -c Release FFmpeg.AutoGen.Redist.windows.x64
       - uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
@@ -29,3 +33,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         with:
           path: FFmpeg.AutoGen/bin/Release/*.snupkg
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          path: FFmpeg.AutoGen.Redist.windows.x64/bin/Release/*.nupkg
+          if-no-files-found: error

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,31 @@
+<Project>
+  <PropertyGroup>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Version>4.3.1</Version>
+    <Authors>Ruslan Balanukhin</Authors>
+    <Company>Rational Core</Company>
+    <Product>FFmpeg.AutoGen</Product>
+    <Copyright>Copyright © Ruslan Balanukhin 2020 All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/Ruslan-B/FFmpeg.AutoGen</PackageProjectUrl>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
+    <PackageTags>ffmpeg</PackageTags>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)FFmpeg.AutoGen.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
+  </ItemGroup>
+</Project>

--- a/FFmpeg.AutoGen.Redist.windows.x64/FFmpeg.AutoGen.Redist.windows.x64.csproj
+++ b/FFmpeg.AutoGen.Redist.windows.x64/FFmpeg.AutoGen.Redist.windows.x64.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <GeneratePackageOnBuild Condition=" $(Configuration) == 'Release' ">true</GeneratePackageOnBuild>
+    <Description>FFmpeg win-x64 redistribution package, use together with FFmpeg.AutoGen package.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="build.props">
+      <PackagePath>build\net40\$(PackageId).props</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="../FFmpeg/bin/x64/*.dll">
+      <PackagePath>runtimes\win-x64\native\%(filename).dll</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/FFmpeg.AutoGen.Redist.windows.x64/build.props
+++ b/FFmpeg.AutoGen.Redist.windows.x64/build.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\*.dll">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/FFmpeg.AutoGen.sln
+++ b/FFmpeg.AutoGen.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpeg.AutoGen.CppSharpUnsafeGenerator", "FFmpeg.AutoGen.CppSharpUnsafeGenerator\FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj", "{2A8E06C6-5A68-4FB4-AE0C-F43B644E3737}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpeg.AutoGen.Redist.windows.x64", "FFmpeg.AutoGen.Redist.windows.x64\FFmpeg.AutoGen.Redist.windows.x64.csproj", "{B5908244-BD07-4BA5-93CA-356B7643D624}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{2A8E06C6-5A68-4FB4-AE0C-F43B644E3737}.Debug|Any CPU.Build.0 = Debug|x64
 		{2A8E06C6-5A68-4FB4-AE0C-F43B644E3737}.Release|Any CPU.ActiveCfg = Release|x64
 		{2A8E06C6-5A68-4FB4-AE0C-F43B644E3737}.Release|Any CPU.Build.0 = Release|x64
+		{B5908244-BD07-4BA5-93CA-356B7643D624}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5908244-BD07-4BA5-93CA-356B7643D624}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5908244-BD07-4BA5-93CA-356B7643D624}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5908244-BD07-4BA5-93CA-356B7643D624}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj
+++ b/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj
@@ -2,19 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net45;net40</TargetFrameworks>
-    <PackageId>FFmpeg.AutoGen</PackageId>
-    <Version>4.3.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Ruslan Balanukhin</Authors>
-    <Company>Rational Core</Company>
-    <Product>FFmpeg.AutoGen</Product>
+    <GeneratePackageOnBuild Condition=" $(Configuration) == 'Release' ">true</GeneratePackageOnBuild>
     <Description>FFmpeg auto generated unsafe bindings for C#/.NET and Mono.</Description>
-    <Copyright>Copyright © Ruslan Balanukhin 2020 All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/Ruslan-B/FFmpeg.AutoGen</PackageProjectUrl>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
-    <FileVersion>$(Version)</FileVersion>
-    <PackageTags>ffmpeg</PackageTags>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <Copyright>Copyright © Ruslan Balanukhin 2020 All rights reserved.</Copyright>    
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,14 +13,6 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>..\FFmpeg.AutoGen.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
-  </ItemGroup>
 
 </Project>

--- a/FFmpeg.AutoGen/FFmpeg.cs
+++ b/FFmpeg.AutoGen/FFmpeg.cs
@@ -49,9 +49,10 @@ namespace FFmpeg.AutoGen
 
         /// <summary>
         ///     Gets or sets the root path for loading libraries.
+        ///     Work out of box with companion ffmpeg distribution package like FFmpeg.AutoGen.Redist.windows.x64
         /// </summary>
         /// <value>The root path.</value>
-        public static string RootPath { get; set; } = string.Empty;
+        public static string RootPath { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
 
         public static GetOrLoadLibrary GetOrLoadLibrary { get; set; }
 
@@ -92,7 +93,7 @@ namespace FFmpeg.AutoGen
             => -Convert.ToInt32(a);
 
         public static int MKTAG<T1, T2, T3, T4>(T1 a, T2 b, T3 c, T4 d)
-            => (int) (Convert.ToUInt32(a) | (Convert.ToUInt32(b) << 8) | (Convert.ToUInt32(c) << 16) |
+            => (int)(Convert.ToUInt32(a) | (Convert.ToUInt32(b) << 8) | (Convert.ToUInt32(c) << 16) |
                       (Convert.ToUInt32(d) << 24));
 
         public static int FFERRTAG<T1, T2, T3, T4>(T1 a, T2 b, T3 c, T4 d)


### PR DESCRIPTION
With redist package, people can get it work out of box with 
```xml
<ItemGroup>
  <PackageReference Include="FFmpeg.AutoGen" Version="4.3.1" />
  <PackageReference Include="FFmpeg.AutoGen.Redist.windows.x64" Version="4.3.1" />
</ItemGroup>
```

This PR includes changes of
1. Move common project properties to Directory.Build.props to avoid duplication
2. Create FFmpeg.AutoGen.Redist.windows.x64 package for win-x64 (other platforms can be created in the same way)
3. Give RootPath a default value to pick up redist dlls 
4. Update github CI to upload FFmpeg.AutoGen.Redist.windows.x64.nuget as build artifact.

Please let me know if any concerns, thanks!