### PR TITLE
Fix memleak in example encoder

### DIFF
--- a/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
+++ b/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
@@ -67,6 +67,7 @@ namespace FFmpeg.AutoGen.Example
                 do
                 {
                     ffmpeg.avcodec_send_frame(_pCodecContext, &frame).ThrowExceptionIfError();
+                    ffmpeg.av_packet_unref(pPacket);
                     error = ffmpeg.avcodec_receive_packet(_pCodecContext, pPacket);
                 } while (error == ffmpeg.AVERROR(ffmpeg.EAGAIN));
 
@@ -76,8 +77,7 @@ namespace FFmpeg.AutoGen.Example
             }
             finally
             {
-                ffmpeg.av_packet_unref(pPacket);
-                ffmpeg.av_free(pPacket);
+                ffmpeg.av_packet_free(&pPacket);
             }
         }
     }

--- a/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
+++ b/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
@@ -67,7 +67,6 @@ namespace FFmpeg.AutoGen.Example
                 do
                 {
                     ffmpeg.avcodec_send_frame(_pCodecContext, &frame).ThrowExceptionIfError();
-
                     error = ffmpeg.avcodec_receive_packet(_pCodecContext, pPacket);
                 } while (error == ffmpeg.AVERROR(ffmpeg.EAGAIN));
 
@@ -78,6 +77,7 @@ namespace FFmpeg.AutoGen.Example
             finally
             {
                 ffmpeg.av_packet_unref(pPacket);
+                ffmpeg.av_free(pPacket);
             }
         }
     }

--- a/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
+++ b/FFmpeg.AutoGen.Example/VideoStreamDecoder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace FFmpeg.AutoGen.Example
@@ -46,11 +45,11 @@ namespace FFmpeg.AutoGen.Example
 
         public void Dispose()
         {
-            ffmpeg.av_frame_unref(_pFrame);
-            ffmpeg.av_free(_pFrame);
+            var pFrame = _pFrame;
+            ffmpeg.av_frame_free(&pFrame);
 
-            ffmpeg.av_packet_unref(_pPacket);
-            ffmpeg.av_free(_pPacket);
+            var pPacket = _pPacket;
+            ffmpeg.av_packet_free(&pPacket);
 
             ffmpeg.avcodec_close(_pCodecContext);
             var pFormatContext = _pFormatContext;


### PR DESCRIPTION
https://github.com/Ruslan-B/FFmpeg.AutoGen/issues/151
Fix can be verified with valgrind
```valgrind --leak-check=full --show-leak-kinds=definite  -- ./FFmpeg.AutoGen.Example```
