### PR TITLE
Add functions to try loading native libraries

### DIFF
--- a/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
+++ b/FFmpeg.AutoGen.Example/FFmpegBinariesHelper.cs
@@ -28,7 +28,12 @@ namespace FFmpeg.AutoGen.Example
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                ffmpeg.RootPath = "/lib/x86_64-linux-gnu/";
+                ffmpeg.TrySetRootPath(
+                    LibraryFlags.AVCodec,
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "/usr/lib",
+                    "/lib/x86_64-linux-gnu"
+                );
             else
                 throw new NotSupportedException(); // fell free add support for platform of your choose
         }

--- a/FFmpeg.AutoGen.Tests/AssemblySetup.cs
+++ b/FFmpeg.AutoGen.Tests/AssemblySetup.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.Runtime.InteropServices;
 
 namespace FFmpeg.AutoGen.Tests
@@ -11,7 +12,12 @@ namespace FFmpeg.AutoGen.Tests
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                ffmpeg.RootPath = "/lib/x86_64-linux-gnu/";
+                ffmpeg.TrySetRootPath(
+                    LibraryFlags.AVCodec,
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "/usr/lib",
+                    "/lib/x86_64-linux-gnu"
+                );
             }
         }
     }

--- a/FFmpeg.AutoGen/FFmpeg.cs
+++ b/FFmpeg.AutoGen/FFmpeg.cs
@@ -65,7 +65,7 @@ namespace FFmpeg.AutoGen
             UnloadLibraries();
             foreach (var libraryName in libraries.ToStrings())
             {
-                if (LoadLibrary(libraryName, false, path) == null)
+                if (LoadLibrary(libraryName, false, path) == IntPtr.Zero)
                     return false;
             }
 

--- a/FFmpeg.AutoGen/LibraryFlags.cs
+++ b/FFmpeg.AutoGen/LibraryFlags.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace FFmpeg.AutoGen
+{
+    [Flags]
+    public enum LibraryFlags : byte
+    {
+        /// No library.
+        None = 0,
+
+        /// avcodec library.
+        AVCodec = 1 << 0,
+        /// avdevice library.
+        AVDevice = 1 << 1,
+        /// avfilter library.
+        AVFilter = 1 << 2,
+        /// avformat library.
+        AVFormat = 1 << 3,
+        /// avutil library.
+        AVUtil = 1 << 4,
+        /// postproc library.
+        PostProc = 1 << 5,
+        /// swresample library.
+        SWResample = 1 << 6,
+        /// swscale library.
+        SWScale = 1 << 7,
+        
+        /// All libav libraries: avcodec, avdevice, avfilter, avformat and avutil.
+        AVAll = AVCodec | AVDevice | AVFilter | AVFormat | AVUtil,
+        /// All libsw libraries: swresample and swscale.
+        SWAll = SWResample | SWScale,
+        /// All libraries: all libav libraries, all libsw libraries, and postproc.
+        All = AVCodec | AVDevice | AVFilter | AVFormat | AVUtil | PostProc | SWResample | SWScale,
+    }
+    
+    public static class LibraryFlagsExtension
+    {
+        /// <summary>
+        /// Gets the names of all the flagged libraries.
+        /// </summary>
+        /// <returns>A list of the names of all the flagged libraries.</returns>
+        public static List<string> ToStrings(this LibraryFlags libraryFlags)
+        {
+            var strings = new List<string>();
+            if (libraryFlags.HasFlag(LibraryFlags.AVCodec)) strings.Add("avcodec");
+            if (libraryFlags.HasFlag(LibraryFlags.AVDevice)) strings.Add("avdevice");
+            if (libraryFlags.HasFlag(LibraryFlags.AVFilter)) strings.Add("avfilter");
+            if (libraryFlags.HasFlag(LibraryFlags.AVFormat)) strings.Add("avformat");
+            if (libraryFlags.HasFlag(LibraryFlags.AVUtil)) strings.Add("avutil");
+            if (libraryFlags.HasFlag(LibraryFlags.PostProc)) strings.Add("postproc");
+            if (libraryFlags.HasFlag(LibraryFlags.SWResample)) strings.Add("swresample");
+            if (libraryFlags.HasFlag(LibraryFlags.SWScale)) strings.Add("swscale");
+            return strings;
+        }
+    }
+}

--- a/FFmpeg.AutoGen/Native/LibraryLoader.cs
+++ b/FFmpeg.AutoGen/Native/LibraryLoader.cs
@@ -83,19 +83,24 @@ namespace FFmpeg.AutoGen.Native
         /// </remarks>
         public static IntPtr LoadNativeLibrary(string libraryName)
         {
-            switch (GetPlatformId())
+            return GetPlatformId() switch
             {
-                case PlatformID.MacOSX:
-                    return MacNativeMethods.dlopen(libraryName, MacNativeMethods.RTLD_NOW);
-                case PlatformID.Unix:
-                    return LinuxNativeMethods.dlopen(libraryName, LinuxNativeMethods.RTLD_NOW);
-                case PlatformID.Win32NT:
-                case PlatformID.Win32S:
-                case PlatformID.Win32Windows:
-                    return WindowsNativeMethods.LoadLibrary(libraryName);
-                default:
-                    throw new PlatformNotSupportedException();
-            }
+                PlatformID.MacOSX => MacNativeMethods.dlopen(libraryName, MacNativeMethods.RTLD_NOW),
+                PlatformID.Unix => LinuxNativeMethods.dlopen(libraryName, LinuxNativeMethods.RTLD_NOW),
+                PlatformID.Win32NT | PlatformID.Win32S | PlatformID.Win32Windows => WindowsNativeMethods.LoadLibrary(libraryName),
+                _ => throw new PlatformNotSupportedException(),
+            };
+        }
+        
+        public static int UnloadNativeLibrary(IntPtr handle)
+        {
+            return GetPlatformId() switch
+            {
+                PlatformID.MacOSX => MacNativeMethods.dlclose(handle),
+                PlatformID.Unix => LinuxNativeMethods.dlclose(handle),
+                PlatformID.Win32NT | PlatformID.Win32S | PlatformID.Win32Windows => WindowsNativeMethods.UnloadLibrary(handle),
+                _ => throw new PlatformNotSupportedException(),
+            };
         }
     }
 }

--- a/FFmpeg.AutoGen/Native/LibraryLoader.cs
+++ b/FFmpeg.AutoGen/Native/LibraryLoader.cs
@@ -98,7 +98,7 @@ namespace FFmpeg.AutoGen.Native
             {
                 PlatformID.MacOSX => MacNativeMethods.dlclose(handle),
                 PlatformID.Unix => LinuxNativeMethods.dlclose(handle),
-                PlatformID.Win32NT | PlatformID.Win32S | PlatformID.Win32Windows => WindowsNativeMethods.UnloadLibrary(handle),
+                PlatformID.Win32NT | PlatformID.Win32S | PlatformID.Win32Windows => WindowsNativeMethods.FreeLibrary(handle),
                 _ => throw new PlatformNotSupportedException(),
             };
         }

--- a/FFmpeg.AutoGen/Native/LinuxNativeMethods.cs
+++ b/FFmpeg.AutoGen/Native/LinuxNativeMethods.cs
@@ -14,5 +14,8 @@ namespace FFmpeg.AutoGen.Native
 
         [DllImport(Libdl)]
         public static extern IntPtr dlopen(string fileName, int flag);
+        
+        [DllImport(Libdl)]
+        public static extern int dlclose(IntPtr handle);
     }
 }

--- a/FFmpeg.AutoGen/Native/MacNativeMethods.cs
+++ b/FFmpeg.AutoGen/Native/MacNativeMethods.cs
@@ -14,5 +14,8 @@ namespace FFmpeg.AutoGen.Native
 
         [DllImport(Libdl)]
         public static extern IntPtr dlopen(string fileName, int flag);
+        
+        [DllImport(Libdl)]
+        public static extern int dlclose(IntPtr handle);
     }
 }

--- a/FFmpeg.AutoGen/Native/WindowsNativeMethods.cs
+++ b/FFmpeg.AutoGen/Native/WindowsNativeMethods.cs
@@ -46,6 +46,6 @@ namespace FFmpeg.AutoGen.Native
         public static extern IntPtr LoadLibrary(string dllToLoad);
         
         [DllImport(Kernel32, SetLastError = true)]
-        public static extern int UnloadLibrary(IntPtr handle);
+        public static extern int FreeLibrary(IntPtr handle);
     }
 }

--- a/FFmpeg.AutoGen/Native/WindowsNativeMethods.cs
+++ b/FFmpeg.AutoGen/Native/WindowsNativeMethods.cs
@@ -44,5 +44,8 @@ namespace FFmpeg.AutoGen.Native
         /// <seealso href="http://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx"/>
         [DllImport(Kernel32, SetLastError = true)]
         public static extern IntPtr LoadLibrary(string dllToLoad);
+        
+        [DllImport(Kernel32, SetLastError = true)]
+        public static extern int UnloadLibrary(IntPtr handle);
     }
 }


### PR DESCRIPTION
I tried to implement a sane way to let any user of `FFmpeg.AutoGen` try out paths and set one that works.
This will close issue #175.

I introduce a `LibraryFlags` enum so that they can select which libraries are necessary for the root path to work, and then 2 methods:
- `TryLoadLibraries` will try to load the specified libraries on one path and return whether it succeeded in doing so.
- `TrySetRootPath` will try to set the root path to one of the pathsthat it has been given, based on whether it can find the libraries there, makig it much simpler to try out different paths.

Some notable things here is that I am assuming that there is an `UnloadLibrary` function on the Windows side. I'll search it up and modify it if the name for it is different.