### PR TITLE
4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,8 @@ UpgradeLog*.XML
 
 *.stackdump
 
+# Rider
+.idea/
+
 # Local 
 /FFmpeg.AutoGen.Example/frame.*.jpg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>4.4.2</Version>
+    <Version>4.4.2.1</Version>
     <Authors>Ruslan Balanukhin</Authors>
     <Company>Rational Core</Company>
     <Product>FFmpeg.AutoGen</Product>

--- a/FFmpeg.AutoGen/FFmpeg.functions.export.g.cs
+++ b/FFmpeg.AutoGen/FFmpeg.functions.export.g.cs
@@ -14657,7 +14657,7 @@ namespace FFmpeg.AutoGen
         /// <summary>Compute the max pixel step for each plane of an image with a format described by pixdesc.</summary>
         /// <param name="max_pixsteps">an array which is filled with the max pixel step for each plane. Since a plane may contain different pixel components, the computed max_pixsteps[plane] is relative to the component in the plane with the max pixel step.</param>
         /// <param name="max_pixstep_comps">an array which is filled with the component for each plane which has the max pixel step. May be NULL.</param>
-        public static void av_image_fill_max_pixsteps(int_array4 @max_pixsteps, ref int_array4 @max_pixstep_comps, AVPixFmtDescriptor* @pixdesc)
+        public static void av_image_fill_max_pixsteps(ref int_array4 @max_pixsteps, ref int_array4 @max_pixstep_comps, AVPixFmtDescriptor* @pixdesc)
         {
             av_image_fill_max_pixsteps_fptr(@max_pixsteps, ref @max_pixstep_comps, @pixdesc);
         }


### PR DESCRIPTION
Fixing #182.
Tested on OSx with FFmpeg v4.4.1 installed via brew.
```
➜  ~ ffmpeg -version
ffmpeg version 4.4.1 Copyright (c) 2000-2021 the FFmpeg developers
built with Apple clang version 13.0.0 (clang-1300.0.29.3)
configuration: --prefix=/usr/local/Cellar/ffmpeg/4.4.1_5 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librist --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-avresample --enable-videotoolbox
libavutil      56. 70.100 / 56. 70.100
libavcodec     58.134.100 / 58.134.100
libavformat    58. 76.100 / 58. 76.100
libavdevice    58. 13.100 / 58. 13.100
libavfilter     7.110.100 /  7.110.100
libavresample   4.  0.  0 /  4.  0.  0
libswscale      5.  9.100 /  5.  9.100
libswresample   3.  9.100 /  3.  9.100
libpostproc    55.  9.100 / 55.  9.100
```