### PR TITLE
Update encoding loop to recommended algorithm; add drain loop.

### DIFF
--- a/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
+++ b/FFmpeg.AutoGen.Example/H264VideoStreamEncoder.cs
@@ -66,19 +66,121 @@ namespace FFmpeg.AutoGen.Example
 
             try
             {
-                int error;
+                // Basic encoding loop explained: 
+                // https://ffmpeg.org/doxygen/4.1/group__lavc__encdec.html
+
+                // Give the encoder a frame to encode
+                ffmpeg.avcodec_send_frame(_pCodecContext, &frame).ThrowExceptionIfError();
+
+                // From https://ffmpeg.org/doxygen/4.1/group__lavc__encdec.html:
+                // For encoding, call avcodec_receive_packet().  On success, it will return an AVPacket with a compressed frame.
+                // Repeat this call until it returns AVERROR(EAGAIN) or an error.
+                // The AVERROR(EAGAIN) return value means that new input data is required to return new output.
+                // In this case, continue with sending input.
+                // For each input frame/packet, the codec will typically return 1 output frame/packet, but it can also be 0 or more than 1.
+                bool hasFinishedWithThisFrame;
 
                 do
                 {
-                    ffmpeg.avcodec_send_frame(_pCodecContext, &frame).ThrowExceptionIfError();
+                    // Clear/wipe the receiving packet
+                    // (not sure if this is needed, since docs for avcoded_receive_packet say that it will call that first-thing
                     ffmpeg.av_packet_unref(pPacket);
-                    error = ffmpeg.avcodec_receive_packet(_pCodecContext, pPacket);
-                } while (error == ffmpeg.AVERROR(ffmpeg.EAGAIN));
 
-                error.ThrowExceptionIfError();
+                    // Receive back a packet; there might be 0, 1 or many packets to receive for an input frame.
+                    var response = ffmpeg.avcodec_receive_packet(_pCodecContext, pPacket);
 
-                using var packetStream = new UnmanagedMemoryStream(pPacket->data, pPacket->size);
-                packetStream.CopyTo(_stream);
+                    bool isPacketValid;
+
+                    if (response == 0)
+                    {
+                        // 0 on success; as in, successfully retrieved a packet, and expecting us to retrieve another one.
+                        isPacketValid = true;
+                        hasFinishedWithThisFrame = false;
+                    }
+                    else if (response == ffmpeg.AVERROR(ffmpeg.EAGAIN))
+                    {
+                        // EAGAIN: there's no more output is available in the current state - user must try to send more input
+                        isPacketValid = false;
+                        hasFinishedWithThisFrame = true;
+                    }
+                    else if (response == ffmpeg.AVERROR(ffmpeg.AVERROR_EOF))
+                    {
+                        // EOF: the encoder has been fully flushed, and there will be no more output packets
+                        isPacketValid = false;
+                        hasFinishedWithThisFrame = true;
+                    }
+                    else
+                    {
+                        // AVERROR(EINVAL): codec not opened, or it is a decoder other errors: legitimate encoding errors
+                        // , otherwise negative error code:
+                        throw new InvalidOperationException($"error from avcodec_receive_packet: {response}");
+                    }
+
+                    if (isPacketValid)
+                    {
+                        using var packetStream = new UnmanagedMemoryStream(pPacket->data, pPacket->size);
+                        packetStream.CopyTo(_stream);
+                    }
+                } while (!hasFinishedWithThisFrame);
+            }
+            finally
+            {
+                ffmpeg.av_packet_free(&pPacket);
+            }
+        }
+
+        public void Drain()
+        {
+            // From https://ffmpeg.org/doxygen/4.1/group__lavc__encdec.html:
+            // End of stream situations. These require "flushing" (aka draining) the codec, as the codec might buffer multiple frames or packets internally for performance or out of necessity (consider B-frames). This is handled as follows:
+            // Instead of valid input, send NULL to the avcodec_send_packet() (decoding) or avcodec_send_frame() (encoding) functions. This will enter draining mode.
+            // 	Call avcodec_receive_frame() (decoding) or avcodec_receive_packet() (encoding) in a loop until AVERROR_EOF is returned. The functions will not return AVERROR(EAGAIN), unless you forgot to enter draining mode.
+
+            var pPacket = ffmpeg.av_packet_alloc();
+
+            try
+            {
+                // Send a null frame to enter draining mode
+                ffmpeg.avcodec_send_frame(_pCodecContext, null).ThrowExceptionIfError();
+
+                bool hasFinishedDraining;
+
+                do
+                {
+                    // Clear/wipe the receiving packet
+                    // (not sure if this is needed, since docs for avcoded_receive_packet say that it will call that first-thing
+                    ffmpeg.av_packet_unref(pPacket);
+
+                    var response = ffmpeg.avcodec_receive_packet(_pCodecContext, pPacket);
+
+                    bool isPacketValid;
+
+                    if (response == 0)
+                    {
+                        // 0 on success; as in, successfully retrieved a packet, and expecting us to retrieve another one.
+                        isPacketValid = true;
+                        hasFinishedDraining = false;
+                    }
+                    else if (response == ffmpeg.AVERROR(ffmpeg.AVERROR_EOF))
+                    {
+                        // EOF: the encoder has been fully flushed, and there will be no more output packets
+                        isPacketValid = false;
+                        hasFinishedDraining = true;
+                    }
+                    else
+                    {
+                        // Some other error.
+                        // Should probably throw here, but in testing we get error -541478725
+                        isPacketValid = false;
+                        hasFinishedDraining = true;
+                    }
+
+                    if (isPacketValid)
+                    {
+                        using var packetStream = new UnmanagedMemoryStream(pPacket->data, pPacket->size);
+                        packetStream.CopyTo(_stream);
+                    }
+                } while (!hasFinishedDraining);
             }
             finally
             {

--- a/FFmpeg.AutoGen.Example/Program.cs
+++ b/FFmpeg.AutoGen.Example/Program.cs
@@ -191,6 +191,8 @@ namespace FFmpeg.AutoGen.Example
                 Console.WriteLine($"frame: {frameNumber}");
                 frameNumber++;
             }
+
+            vse.Drain();
         }
 
         private static byte[] GetBitmapData(Bitmap frameBitmap)


### PR DESCRIPTION
#191 mentions that the code in H264VideoStreamEncoder.cs isn't a "correct" encoding loop. 
I implemented the recommended loop from https://ffmpeg.org/doxygen/4.1/group__lavc__encdec.html
It's a bit more verbose than it needs to be, but explains the algorithm as it goes.

I think the original H264VideoStreamEncoder.cs had 2 problems:
- the output would have missing (or maybe duplicated) frames at the start, because it kept sending the same frame in rather than sending it once and then reading packets (if any) until EAGAIN
- the output would have missing frames at the end, because it didn't drain.

Thanks for your great work in this project!