### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Steps to generate:
 - Run ```FFmpeg.AutoGen.CppSharpUnsafeGenerator;```
 - All files with extension ```*.g.cs```  in ```FFmpeg.AutoGen``` project will be regenerated.
 
-## Speicial Thanks
+## Special Thanks
 <a href="https://jetbrains.com">
 <img src="https://account.jetbrains.com/static/images/jetbrains-logo-inv.svg" data-canonical-src="https://account.jetbrains.com/static/images/jetbrains-logo-inv.svg" width="128" height="128" />
  <br/>


### PR DESCRIPTION
Fixed "Special" being misspelled as "Speicial" in README.md