### PR TITLE
Basic multiplatform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,9 @@ UpgradeLog*.XML
 
 *.stackdump
 
+# JetBrains Rider
+.idea/
+*.sln.iml
+
 # Local 
 /FFmpeg.AutoGen.Example/frame.*.jpg

--- a/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj
+++ b/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net472;net45</TargetFrameworks>
     <GeneratePackageOnBuild Condition=" $(Configuration) == 'Release' ">true</GeneratePackageOnBuild>
     <Description>FFmpeg auto generated unsafe bindings for C#/.NET and Mono.</Description>
   </PropertyGroup>

--- a/FFmpeg.AutoGen/FFmpeg.cs
+++ b/FFmpeg.AutoGen/FFmpeg.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FFmpeg.AutoGen.Native;
 
 namespace FFmpeg.AutoGen
@@ -38,11 +39,23 @@ namespace FFmpeg.AutoGen
         {
             GetOrLoadLibrary = libraryName => LoadLibrary(libraryName, true);
 
+#if NET
+            //BSD has #define EAGAIN 35 in errno.h, other OS have EAGAIN 11. Apple is based on BSD 
+            bool bsdStyleErrno =
+                OperatingSystem.IsFreeBSD()
+                || OperatingSystem.IsMacCatalyst()
+                || OperatingSystem.IsMacOS()
+                || OperatingSystem.IsIOS()
+                || OperatingSystem.IsTvOS()
+                || OperatingSystem.IsWatchOS();
+            EAGAIN = bsdStyleErrno ? 35 : 11;
+#else
             EAGAIN = LibraryLoader.GetPlatformId() switch
             {
                 PlatformID.MacOSX => 35,
                 _ => 11
             };
+#endif
         }
 
         /// <summary>

--- a/FFmpeg.AutoGen/Native/LibraryLoader.cs
+++ b/FFmpeg.AutoGen/Native/LibraryLoader.cs
@@ -16,6 +16,18 @@ namespace FFmpeg.AutoGen.Native
             {
 #if NET45 || NET40
                 return Environment.OSVersion.Platform;
+#elif NET
+                if (OperatingSystem.IsWindows())
+                    return PlatformID.Win32NT;
+                if (OperatingSystem.IsMacCatalyst()
+                    || OperatingSystem.IsMacOS()
+                    || OperatingSystem.IsIOS()
+                    || OperatingSystem.IsTvOS()
+                    || OperatingSystem.IsWatchOS())
+                    return PlatformID.MacOSX; // all share similar .dylib calling style. But only static libs on iOS store apps!
+                if (OperatingSystem.IsAndroid() || OperatingSystem.IsFreeBSD() || OperatingSystem.IsLinux())
+                    return PlatformID.Unix;
+                return null;
 #else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return PlatformID.Win32NT;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformID.Unix;

--- a/FFmpeg.AutoGen/Native/LibraryLoader.cs
+++ b/FFmpeg.AutoGen/Native/LibraryLoader.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace FFmpeg.AutoGen.Native
 {
-    public delegate PlatformID GetPlatformId();
+    public delegate PlatformID? GetPlatformId();
 
     public delegate string GetNativeLibraryName(string libraryName, int version);
 
@@ -20,7 +20,7 @@ namespace FFmpeg.AutoGen.Native
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return PlatformID.Win32NT;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return PlatformID.Unix;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return PlatformID.MacOSX;
-                throw new PlatformNotSupportedException();
+                return null;
 #endif
             };
 


### PR DESCRIPTION
I have static DLLImport projects for iOS and MacCatalyst. They rely on the data structures provided in FFmpeg.AutoGen.
Unfortunately  static ffmpeg ctor currently fails on those platforms with UnsupportedOperationException. 
Her's a small fix to prevent that. As a workaround until a final solution is in place.

Also .NET6 as a separate target to allow specific code for the most  relevant target framework. This way all platforms can be properly detected. EAGAIN is 35 on BSD style platforms (notably Apple) and 11 on all others.