### PR TITLE
Change for loop to Buffer.MemoryCopyTo improve performance, add the manually controllable macro HAS_SYSTE…

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generation/FixedArraysGenerator.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generation/FixedArraysGenerator.cs
@@ -65,11 +65,11 @@ internal sealed class FixedArraysGenerator : GeneratorBase<FixedArrayDefinition>
 
         WriteLine($"public {elementType}[] ToArray()");
         using (BeginBlock())
-            WriteLine($"var a = new {elementType}[{length}]; for (uint i = 0; i < {length}; i++) a[i] = _[i]; return a;");
+            WriteLine(PrimitiveFixedArraysGeneratorHelper.GetBlockOfToArray(elementType, length));
 
         WriteLine($"public void UpdateFrom({elementType}[] array)");
         using (BeginBlock())
-            WriteLine($"uint i = 0; foreach(var value in array) {{ _[i++] = value; if (i >= {length}) return; }}");
+            WriteLine(PrimitiveFixedArraysGeneratorHelper.GetBlockOfUpdateFrom(elementType, length));
     }
 
     private void WriteComplexFixedArray(string elementType, int length)

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generation/PrimitiveFixedArraysGeneratorHelper.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Generation/PrimitiveFixedArraysGeneratorHelper.cs
@@ -1,0 +1,89 @@
+﻿//#if (NETSTANDARD1_3_OR_GREATER) || (NET46_OR_GREATER) || NETSTANDARD1_3 || NETSTANDARD1_4 || NETSTANDARD1_5 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETSTANDARD2_1 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48 || NET5_0 || NET6_0
+#define HAS_SYSTEM_MEMORY_COPY
+//#endif
+
+using System;
+using System.Collections.Generic;
+
+
+
+namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator.Generation
+{
+    internal interface FixedArraysFunctionBlockGenerator
+    {
+        string GetBlockOfToArray(string elementType, int length);
+        string GetBlockOfUpdateFrom(string elementType, int length);
+    }
+
+    internal class PrimitiveFixedArraysGeneratorHelper
+    {
+        static private readonly string BYTE_KEY = "byte";
+        static private Dictionary<string, FixedArraysFunctionBlockGenerator>  fixedArraysBlockGenerators = new Dictionary<string, FixedArraysFunctionBlockGenerator>();
+        static PrimitiveFixedArraysGeneratorHelper() {
+            fixedArraysBlockGenerators.Add(BYTE_KEY, new ByteFixedArraysFunctionBlockGenerator());
+        }
+
+        static public string GetBlockOfToArray(string elementType, int length)
+        {
+            String result = null;
+            if (fixedArraysBlockGenerators.ContainsKey(elementType))
+            {
+                FixedArraysFunctionBlockGenerator generator = fixedArraysBlockGenerators[elementType];
+                result = generator.GetBlockOfToArray(elementType, length);
+            }
+            if (string.IsNullOrEmpty(result))
+            {
+                result = $"var a = new {elementType}[{length}]; for (uint i = 0; i < {length}; i++) a[i] = _[i]; return a;";
+            }
+            return result;
+        }
+
+
+        static public string GetBlockOfUpdateFrom(string elementType, int length)
+        {
+            String result = null;
+            if (fixedArraysBlockGenerators.ContainsKey(elementType))
+            {
+                FixedArraysFunctionBlockGenerator generator = fixedArraysBlockGenerators[elementType];
+                result = generator.GetBlockOfUpdateFrom(elementType, length);
+            }
+            if (string.IsNullOrEmpty(result))
+            {
+                result = $"uint i = 0; foreach(var value in array) {{ _[i++] = value; if (i >= {length}) return; }}";
+            }
+            return result;
+        }
+
+    }
+
+    internal class ByteFixedArraysFunctionBlockGenerator : FixedArraysFunctionBlockGenerator
+    {   
+        static private int USE_COPY_MIN_LENGTH = 256;
+        public string GetBlockOfToArray(string elementType, int length)
+        {
+            if (length >= USE_COPY_MIN_LENGTH)
+            {
+                //return $"var a = new {elementType}[{length}];Array.Copy(_, a, {length}); return a;";
+#if HAS_SYSTEM_MEMORY_COPY
+                return $@"var a = new {elementType}[{length}];fixed (byte* src = _, dst = a){{ Buffer.MemoryCopy(src, dst, {length}, {length}); }} return a;";
+#endif
+            }
+            return null;
+        }
+
+        public string GetBlockOfUpdateFrom(string elementType, int length)
+        {
+            if (length >= USE_COPY_MIN_LENGTH)
+            {
+                //return $"Array.Copy(array, _, Math.Min({length}, array.Length));";
+#if HAS_SYSTEM_MEMORY_COPY
+                return $@"fixed (byte* src = array, dst = _){{ Buffer.MemoryCopy(src, dst, {length}, Math.Min({length}, array.Length)); }}";
+#endif
+
+            }
+            return null;
+        }
+    }
+
+
+}


### PR DESCRIPTION
…M_MEMORY_COPY, which can change the code from a for loop to the form of Buffer.MemoryCopy. For example, the method ToArray and UpdateFrom of the structure byte_array61440:

public byte[] ToArray()
{
	var a = new byte[61440]; for (uint i = 0; i < 61440; i++) a[i] = _[i]; return a;
}
becomes
public byte[] ToArray()
{
	var a = new byte[61440];fixed (byte* src = _, dst = a){ Buffer.MemoryCopy(src, dst, 61440, 61440); } return a;
}

public void UpdateFrom(byte[] array)
{
	uint i = 0; foreach(var value in array) { _[i++] = value; if (i >= 61440) return; }
}
becomes
public void UpdateFrom(byte[] array)
{
	fixed (byte* src = array, dst = _){ Buffer.MemoryCopy(src, dst, 61440, Math.Min(61440, array.Length)); }
}