### PR TITLE
Add option to use UnmanagedType.LPUTF8Str for all string marshalling

### DIFF
--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/CliOptions.cs
@@ -59,6 +59,11 @@ public class CliOptions
         HelpText = "Print details during execution.")]
     public bool Verbose { get; set; }
 
+    [Option("noCustomStringMarshal",
+        Default = false,
+        HelpText = "Don't use custom string marshallers; all strings are marshalled as UnmanagedType.LPUTF8Str regardless of .NET target framework.")]
+    public bool NoCustomStringMarshal { get; set; }
+
     public static CliOptions ParseArgumentsStrict(string[] args)
     {
         var result = CommandLine.Parser.Default.ParseArguments<CliOptions>(args);

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/FunctionProcessor.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/FunctionProcessor.cs
@@ -12,6 +12,8 @@ internal class FunctionProcessor
 {
     private const string ReturnMarshalAsConstCharPtr = "[return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]";
 
+    private const string ReturnMarshalAsLPUTF8Str = "[return: MarshalAs(UnmanagedType.LPUTF8Str)]";
+
     private const string MarshalAsUTF8Macros =
         "    \r\n" +
         "    #if NETSTANDARD2_1_OR_GREATER\r\n" +
@@ -20,6 +22,8 @@ internal class FunctionProcessor
         "    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]\r\n" +
         "    #endif\r\n" +
         "   ";
+
+    private const string MarshalAsLPUTF8Str = "[MarshalAs(UnmanagedType.LPUTF8Str)]";
 
 
     private readonly ProcessingContext _context;
@@ -126,7 +130,7 @@ internal class FunctionProcessor
                 PrimitiveType.Char => new TypeDefinition
                 {
                     Name = "string",
-                    Attributes = new[] { MarshalAsUTF8Macros }
+                    Attributes = new[] { _context.NoCustomStringMarshal ? MarshalAsLPUTF8Str : MarshalAsUTF8Macros }
                 },
                 PrimitiveType.Void => new TypeDefinition
                 {
@@ -153,7 +157,7 @@ internal class FunctionProcessor
                 PrimitiveType.Char => new TypeDefinition
                 {
                     Name = "string",
-                    Attributes = new[] { ReturnMarshalAsConstCharPtr }
+                    Attributes = new[] { _context.NoCustomStringMarshal ? ReturnMarshalAsLPUTF8Str : ReturnMarshalAsConstCharPtr }
                 },
                 PrimitiveType.Void => new TypeDefinition
                 {

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/ProcessingContext.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/ProcessingContext.cs
@@ -12,6 +12,7 @@ internal sealed record ProcessingContext
     public Dictionary<string, string> WellKnownEnumItems { get; init; } = new();
     public Dictionary<string, FunctionExport> FunctionExportMap { get; init; } = new();
     public List<IDefinition> Definitions { get; init; } = new();
+    public bool NoCustomStringMarshal { get; init; } = false;
 
     public void AddDefinition(IDefinition definition)
     {

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -48,7 +48,8 @@ internal class Program
             FunctionExportMap = functionExports
                 .GroupBy(x => x.Name)
                 .Select(x => x.First()) // Eliminate duplicated names
-                .ToDictionary(x => x.Name)
+                .ToDictionary(x => x.Name),
+            NoCustomStringMarshal = options.NoCustomStringMarshal,
         };
         var processor = new ASTProcessor(processingContext);
         astContexts.ForEach(processor.Process);


### PR DESCRIPTION
My project uses a custom build of ffmpeg where all strings are UTF8, which means the default `ConstCharPtrMarshaler` will not return the right marshalled values.

We need an option to skip this custom marshal class and use the standard `UnmanagedType.LPUTF8Str` for all string marshalling.