### PR TITLE
Fix delegate return type: byte* instead of string for const char*

### DIFF
--- a/FFmpeg.AutoGen.Abstractions/generated/Delegates.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/Delegates.g.cs
@@ -106,7 +106,7 @@ public unsafe struct AVClass_get_category_func
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public unsafe delegate string AVClass_item_name (void* @ctx);
+public unsafe delegate byte* AVClass_item_name (void* @ctx);
 public unsafe struct AVClass_item_name_func
 {
     public IntPtr Pointer;

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/FunctionProcessor.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Processing/FunctionProcessor.cs
@@ -82,12 +82,27 @@ internal class FunctionProcessor
         {
             Name = $"{name}_func",
             FunctionName = name,
-            ReturnType = GetReturnType(functionType.ReturnType.Type, name),
+            ReturnType = GetDelegateReturnType(functionType.ReturnType.Type, name),
             Parameters = functionType.Parameters.Select(GetParameter).ToArray()
         };
         _context.AddDefinition(@delegate);
 
         return @delegate;
+    }
+
+    private TypeDefinition GetDelegateReturnType(Type type, string name)
+    {
+        // For delegates (function pointers), const char* must be byte* not string,
+        // because string marshaling does not work with unmanaged function pointers.
+        if (type is PointerType pointerType &&
+            pointerType.QualifiedPointee.Qualifiers.IsConst &&
+            pointerType.Pointee is BuiltinType builtinType &&
+            builtinType.Type == PrimitiveType.Char)
+        {
+            return new TypeDefinition { Name = "byte*" };
+        }
+
+        return GetReturnType(type, name);
     }
 
     private FunctionParameter GetParameter(Parameter parameter, int position)

--- a/FFmpeg.AutoGen/generated/Delegates.g.cs
+++ b/FFmpeg.AutoGen/generated/Delegates.g.cs
@@ -106,7 +106,7 @@ public unsafe struct AVClass_get_category_func
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public unsafe delegate string AVClass_item_name (void* @ctx);
+public unsafe delegate byte* AVClass_item_name (void* @ctx);
 public unsafe struct AVClass_item_name_func
 {
     public IntPtr Pointer;


### PR DESCRIPTION
## Summary

- Fix delegate (function pointer) return types in the code generator
- Delegates like `AVClass_item_name` now correctly return `byte*` instead of `string` for `const char*` C functions
- String marshaling does not work with unmanaged function pointers, causing `AccessViolationException`

Fixes #271

## Test plan

- [x] Generator runs without errors
- [x] Build succeeds (0 warnings, 0 errors)
- [x] All 17 tests pass
- [x] Example project runs successfully (decode + encode)