### PR TITLE
Add FFmpeg runtime binaries download script

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Link="README.md" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)FFmpeg\download-ffmpeg-runtime.ps1" Pack="true" PackagePath="tools\" />
   </ItemGroup>
   
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- The package intentionally includes a manually-run PowerShell helper script. -->
+    <NoWarn>$(NoWarn);NU5111</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/FFmpeg/download-ffmpeg-runtime.ps1
+++ b/FFmpeg/download-ffmpeg-runtime.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Downloads FFmpeg shared libraries for application run-time use.
+
+.DESCRIPTION
+    Downloads a pinned FFmpeg full-build-shared release from GyanD/codexffmpeg
+    and copies DLLs from the archive's bin directory to DestinationFolder.
+    Use IncludeExes to also copy FFmpeg command-line tools from the same bin directory.
+
+.PARAMETER Version
+    FFmpeg release tag on GyanD/codexffmpeg (default: 8.1).
+
+.PARAMETER DestinationFolder
+    Destination folder for the FFmpeg binaries.
+
+.PARAMETER IncludeExes
+    Also copy .exe files from the FFmpeg bin directory.
+
+.PARAMETER Force
+    Overwrite existing FFmpeg binaries.
+
+.EXAMPLE
+    .\download-ffmpeg-runtime.ps1 -DestinationFolder .\bin\x64
+
+.EXAMPLE
+    .\download-ffmpeg-runtime.ps1 -Version 8.1 -DestinationFolder .\publish -IncludeExes -Force
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version = "8.1",
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DestinationFolder,
+
+    [switch]$IncludeExes,
+
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$DestinationFolderPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($DestinationFolder)
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "FFmpeg.AutoGen"
+$TempDir = Join-Path $TempRoot ([System.Guid]::NewGuid().ToString("N"))
+
+$ArchiveName = "ffmpeg-$Version-full_build-shared.zip"
+$Url = "https://github.com/GyanD/codexffmpeg/releases/download/$Version/$ArchiveName"
+
+try {
+    if ((Test-Path (Join-Path $DestinationFolderPath "avcodec-*.dll")) -and -not $Force) {
+        Write-Host "FFmpeg DLLs already exist in $DestinationFolderPath"
+        Write-Host "Re-run with -Force to overwrite, or delete the existing FFmpeg DLLs manually."
+        exit 0
+    }
+
+    Write-Host "Downloading FFmpeg $Version from $Url"
+
+    New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+    $ArchivePath = Join-Path $TempDir $ArchiveName
+
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $ArchivePath -UseBasicParsing
+    } catch {
+        Write-Error "Failed to download FFmpeg $Version. URL: $Url`n$_"
+        exit 1
+    }
+
+    Write-Host "Extracting..."
+    Expand-Archive -Path $ArchivePath -DestinationPath $TempDir -Force
+
+    $ExtractedDir = Get-ChildItem -Path $TempDir -Directory | Where-Object { $_.Name -like "ffmpeg-*" } | Select-Object -First 1
+    if (-not $ExtractedDir) {
+        Write-Error "Could not find extracted FFmpeg directory in $TempDir"
+        exit 1
+    }
+
+    $BinarySource = Join-Path $ExtractedDir.FullName "bin"
+
+    if (-not (Test-Path -Path $BinarySource -PathType Container)) {
+        Write-Error "Expected bin directory not found: $BinarySource"
+        exit 1
+    }
+
+    $DllFiles = @(Get-ChildItem -Path $BinarySource -Filter "*.dll" -File)
+    if ($DllFiles.Count -eq 0) {
+        Write-Error "No DLL files found in $BinarySource"
+        exit 1
+    }
+
+    New-Item -ItemType Directory -Force -Path $DestinationFolderPath | Out-Null
+
+    Write-Host "Copying DLLs to $DestinationFolderPath"
+    foreach ($DllFile in $DllFiles) {
+        Copy-Item -LiteralPath $DllFile.FullName -Destination $DestinationFolderPath -Force
+    }
+
+    $ExeFiles = @()
+    if ($IncludeExes) {
+        $ExeFiles = @(Get-ChildItem -Path $BinarySource -Filter "*.exe" -File)
+
+        Write-Host "Copying EXEs to $DestinationFolderPath"
+        foreach ($ExeFile in $ExeFiles) {
+            Copy-Item -LiteralPath $ExeFile.FullName -Destination $DestinationFolderPath -Force
+        }
+    }
+
+    $Summary = "Done! FFmpeg ${Version}: $($DllFiles.Count) DLLs"
+    if ($IncludeExes) {
+        $Summary += ", $($ExeFiles.Count) EXEs"
+    }
+
+    Write-Host "$Summary copied to $DestinationFolderPath."
+} finally {
+    if (Test-Path -Path $TempDir) {
+        Remove-Item -Recurse -Force $TempDir
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Run the download script to get the required DLLs:
 ```powershell
 .\FFmpeg\download-ffmpeg.ps1
 ```
+NuGet packages also include a `tools\download-ffmpeg-runtime.ps1` helper that copies only the FFmpeg run-time binaries to your application output folder:
+```powershell
+.\tools\download-ffmpeg-runtime.ps1 -DestinationFolder .\bin\x64
+```
 Please check the example project, it shows how to specify the path to libraries.
 
 - on OS X:  


### PR DESCRIPTION
## Description

Adds a new `FFmpeg\download-ffmpeg-runtime.ps1` helper script for acquiring FFmpeg run-time binaries from the pinned GyanD/codexffmpeg full-build-shared release. The script requires a `DestinationFolder`, copies only `.dll` files from the extracted FFmpeg `bin` directory by default, and supports `-IncludeExes` to also copy `.exe` files.

The helper is included in NuGet packages under `tools\download-ffmpeg-runtime.ps1`, and the README now documents the package helper usage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code generation update
- [ ] Dependency update

## Related Issues

Related to #350

## Testing

- [x] I have tested my changes locally
- [ ] I have run `dotnet build -c Release` successfully
- [ ] I have run `dotnet test -c Release` successfully
- [ ] I have tested with the example project if applicable

Validated locally with:

```powershell
[System.Management.Automation.Language.Parser]::ParseFile(...)
.\FFmpeg\download-ffmpeg-runtime.ps1 -DestinationFolder <temp-folder-with-existing-avcodec-dll>
dotnet build .\FFmpeg.AutoGen\FFmpeg.AutoGen.csproj -c Release --no-restore
dotnet pack .\FFmpeg.AutoGen\FFmpeg.AutoGen.csproj -c Release --no-build
```

The generated package was checked to confirm it contains `tools/download-ffmpeg-runtime.ps1`.

## Checklist

- [x] My code follows the project's code style
- [x] I have updated the documentation if needed
- [ ] I have added tests for new functionality if applicable
- [ ] All existing tests pass
- [x] I have checked that my changes don't introduce new warnings

## Additional Notes

The new `Directory.Build.targets` suppresses `NU5111` because the package intentionally includes a manually-run PowerShell helper script under `tools\`; it is not intended to run as a NuGet install/init hook.
