### PR TITLE
Drop the stale package reference, ignore lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ FFmpeg/bin/
 # Claude
 .claude/
 CLAUDE.md
+
+# C# Dev Kit language service cache
+*.lscache

--- a/FFmpeg.AutoGen/FFmpeg.cs
+++ b/FFmpeg.AutoGen/FFmpeg.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FFmpeg.AutoGen;
 
@@ -25,8 +25,11 @@ public static partial class ffmpeg
 
 
     /// <summary>
-    ///     Gets or sets the root path for loading libraries.
-    ///     Work out of box with companion ffmpeg distribution package like FFmpeg.AutoGen.Redist.windows.x64
+    ///     Gets or sets the directory the native FFmpeg libraries are loaded from. Defaults to the
+    ///     application's base directory. This project neither builds nor distributes the binaries,
+    ///     so they can come from anywhere - a native NuGet package, a system install, or a folder
+    ///     the application ships. What has to match is the ABI the bindings were generated against,
+    ///     since the libraries are resolved by versioned name.
     /// </summary>
     /// <value>The root path.</value>
     public static string RootPath { get; set; } = AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
Two unrelated bits of housekeeping that were both one-liners.

**The `RootPath` doc pointed at a package that is gone.** It advertised a "companion ffmpeg distribution package like `FFmpeg.AutoGen.Redist.windows.x64`". Searching nuget.org for `ffmpeg.autogen.redist` returns zero results, so the one place in the library that told people where to get binaries pointed at nothing.

This project neither builds nor distributes the native libraries, and the loader does not care where they came from — a native NuGet package, a system install, or a folder the application ships all work. The doc says that now instead of naming a source, and states the part that actually matters: libraries are resolved by versioned name, so the ABI has to match what the bindings were generated against.

Came out of #350, which asked the same question from the other side.

**`*.lscache` is now ignored.** The C# Dev Kit extension drops a `<project>.csproj.lscache` next to every project as soon as the solution is opened — nine of them here — and they were showing up as untracked noise in every `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
