### PR TITLE
Report unparsed headers, and bind seven of them

### DIFF
--- a/FFmpeg.AutoGen.Abstractions/FFmpeg.AutoGen.Abstractions.csproj.lscache
+++ b/FFmpeg.AutoGen.Abstractions/FFmpeg.AutoGen.Abstractions.csproj.lscache
@@ -1,0 +1,381 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.0
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Abstractions
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.0\FFmpeg.AutoGen.Abstractions.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=7.3
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Abstractions
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.0/FFmpeg.AutoGen.Abstractions.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.0\FFmpeg.AutoGen.Abstractions.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.0\FFmpeg.AutoGen.Abstractions.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+ConstCharPtrMarshaler.cs
+FFmpeg.cs
+generated/
+ Arrays.g.cs
+ Delegates.g.cs
+ Enums.g.cs
+ ffmpeg.functions.facade.g.cs
+ ffmpeg.functions.inline.g.cs
+ ffmpeg.macros.g.cs
+ Structs.g.cs
+ vectors.g.cs
+IFixedArray.cs
+obj/Debug/netstandard2.0/
+ .NETStandard,Version=v2.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Abstractions.AssemblyInfo.cs
+UTF8Marshaler.cs
+
+[metadataReferences]
+<NUGET>/netstandard.library/2.0.3/build/netstandard2.0/ref/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.ObjectModel.dll
+ System.Reflection.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.0/FFmpeg.AutoGen.Abstractions.GeneratedMSBuildEditorConfig.editorconfig
+
+---
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.1
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Abstractions
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.1\FFmpeg.AutoGen.Abstractions.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Abstractions
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.1\FFmpeg.AutoGen.Abstractions.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.Abstractions.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+ConstCharPtrMarshaler.cs
+FFmpeg.cs
+generated/
+ Arrays.g.cs
+ Delegates.g.cs
+ Enums.g.cs
+ ffmpeg.functions.facade.g.cs
+ ffmpeg.functions.inline.g.cs
+ ffmpeg.macros.g.cs
+ Structs.g.cs
+ vectors.g.cs
+IFixedArray.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Abstractions.AssemblyInfo.cs
+UTF8Marshaler.cs
+
+[metadataReferences]
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.Abstractions/generated/Arrays.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/Arrays.g.cs
@@ -200,6 +200,72 @@ public unsafe struct AVComponentDescriptor4 : IFixedArray<AVComponentDescriptor>
     public static implicit operator AVComponentDescriptor[](AVComponentDescriptor4 @struct) => @struct.ToArray();
 }
 
+public unsafe struct AVDRMLayerDescriptor4 : IFixedArray<AVDRMLayerDescriptor>
+{
+    public static readonly int ArrayLength = 4;
+    public int Length => 4;
+    AVDRMLayerDescriptor _0; AVDRMLayerDescriptor _1; AVDRMLayerDescriptor _2; AVDRMLayerDescriptor _3;
+    
+    public AVDRMLayerDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMLayerDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMLayerDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMLayerDescriptor[] ToArray()
+    {
+        fixed (AVDRMLayerDescriptor* p0 = &_0) { var a = new AVDRMLayerDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMLayerDescriptor[] array)
+    {
+        fixed (AVDRMLayerDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMLayerDescriptor[](AVDRMLayerDescriptor4 @struct) => @struct.ToArray();
+}
+
+public unsafe struct AVDRMObjectDescriptor4 : IFixedArray<AVDRMObjectDescriptor>
+{
+    public static readonly int ArrayLength = 4;
+    public int Length => 4;
+    AVDRMObjectDescriptor _0; AVDRMObjectDescriptor _1; AVDRMObjectDescriptor _2; AVDRMObjectDescriptor _3;
+    
+    public AVDRMObjectDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMObjectDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMObjectDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMObjectDescriptor[] ToArray()
+    {
+        fixed (AVDRMObjectDescriptor* p0 = &_0) { var a = new AVDRMObjectDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMObjectDescriptor[] array)
+    {
+        fixed (AVDRMObjectDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMObjectDescriptor[](AVDRMObjectDescriptor4 @struct) => @struct.ToArray();
+}
+
+public unsafe struct AVDRMPlaneDescriptor4 : IFixedArray<AVDRMPlaneDescriptor>
+{
+    public static readonly int ArrayLength = 4;
+    public int Length => 4;
+    AVDRMPlaneDescriptor _0; AVDRMPlaneDescriptor _1; AVDRMPlaneDescriptor _2; AVDRMPlaneDescriptor _3;
+    
+    public AVDRMPlaneDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMPlaneDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMPlaneDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMPlaneDescriptor[] ToArray()
+    {
+        fixed (AVDRMPlaneDescriptor* p0 = &_0) { var a = new AVDRMPlaneDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMPlaneDescriptor[] array)
+    {
+        fixed (AVDRMPlaneDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMPlaneDescriptor[](AVDRMPlaneDescriptor4 @struct) => @struct.ToArray();
+}
+
 public unsafe struct byte_ptr4 : IFixedArray
 {
     public static readonly int ArrayLength = 4;
@@ -442,6 +508,28 @@ public unsafe struct byte6 : IFixedArray<byte>
     public static implicit operator byte[](byte6 @struct) => @struct.ToArray();
 }
 
+public unsafe struct byte6x12 : IFixedArray<byte12>
+{
+    public static readonly int ArrayLength = 6;
+    public int Length => 6;
+    byte12 _0; byte12 _1; byte12 _2; byte12 _3; byte12 _4; byte12 _5;
+    
+    public byte12 this[uint i]
+    {
+        get { if (i >= 6) throw new ArgumentOutOfRangeException(); fixed (byte12* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 6) throw new ArgumentOutOfRangeException(); fixed (byte12* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public byte12[] ToArray()
+    {
+        fixed (byte12* p0 = &_0) { var a = new byte12[6]; for (uint i = 0; i < 6; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(byte12[] array)
+    {
+        fixed (byte12* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 6) return; } }
+    }
+    public static implicit operator byte12[](byte6x12 @struct) => @struct.ToArray();
+}
+
 public unsafe struct ushort6 : IFixedArray<ushort>
 {
     public static readonly int ArrayLength = 6;
@@ -638,6 +726,28 @@ public unsafe struct int9 : IFixedArray<int>
         uint i = 0; foreach(var value in array) { _[i++] = value; if (i >= 9) return; }
     }
     public static implicit operator int[](int9 @struct) => @struct.ToArray();
+}
+
+public unsafe struct byte12 : IFixedArray<byte>
+{
+    public static readonly int ArrayLength = 12;
+    public int Length => 12;
+    fixed byte _[12];
+    
+    public byte this[uint i]
+    {
+        get => _[i];
+        set => _[i] = value;
+    }
+    public byte[] ToArray()
+    {
+        var a = new byte[12]; for (uint i = 0; i < 12; i++) a[i] = _[i]; return a;
+    }
+    public void UpdateFrom(byte[] array)
+    {
+        uint i = 0; foreach(var value in array) { _[i++] = value; if (i >= 12) return; }
+    }
+    public static implicit operator byte[](byte12 @struct) => @struct.ToArray();
 }
 
 public unsafe struct AVHDRPlusPercentile15 : IFixedArray<AVHDRPlusPercentile>

--- a/FFmpeg.AutoGen.Abstractions/generated/Delegates.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/Delegates.g.cs
@@ -41,6 +41,38 @@ public unsafe struct av_buffer_pool_init2_pool_free_func
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_and_eval_funcs1 (void* @p0, double @p1);
+public unsafe struct av_expr_parse_and_eval_funcs1_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_and_eval_funcs1_func(av_expr_parse_and_eval_funcs1 func) => new av_expr_parse_and_eval_funcs1_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_and_eval_funcs2 (void* @p0, double @p1, double @p2);
+public unsafe struct av_expr_parse_and_eval_funcs2_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_and_eval_funcs2_func(av_expr_parse_and_eval_funcs2 func) => new av_expr_parse_and_eval_funcs2_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_funcs1 (void* @p0, double @p1);
+public unsafe struct av_expr_parse_funcs1_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_funcs1_func(av_expr_parse_funcs1 func) => new av_expr_parse_funcs1_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_funcs2 (void* @p0, double @p1, double @p2);
+public unsafe struct av_expr_parse_funcs2_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_funcs2_func(av_expr_parse_funcs2 func) => new av_expr_parse_funcs2_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void av_log_set_callback_callback (void* @p0, int @p1,     
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -84,6 +116,14 @@ public unsafe struct av_tree_insert_cmp_func
 {
     public IntPtr Pointer;
     public static implicit operator av_tree_insert_cmp_func(av_tree_insert_cmp func) => new av_tree_insert_cmp_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate void av_tx_init_tx (AVTXContext* @s, void* @out, void* @in, long @stride);
+public unsafe struct av_tx_init_tx_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_tx_init_tx_func(av_tx_init_tx func) => new av_tx_init_tx_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/FFmpeg.AutoGen.Abstractions/generated/Enums.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/Enums.g.cs
@@ -1009,6 +1009,13 @@ public enum AVDiscard : int
     @AVDISCARD_ALL = 48,
 }
 
+/// <summary>API-specific header for AV_HWDEVICE_TYPE_DRM.</summary>
+public enum AvDrmMax : int
+{
+    /// <summary>The maximum number of layers/planes in a DRM frame.</summary>
+    @AV_DRM_MAX_PLANES = 4,
+}
+
 /// <summary>The duration of a video can be estimated through various ways, and this enum can be used to know how the duration was estimated.</summary>
 public enum AVDurationEstimationMethod : int
 {
@@ -1018,6 +1025,20 @@ public enum AVDurationEstimationMethod : int
     @AVFMT_DURATION_FROM_STREAM = 1,
     /// <summary>Duration estimated from bitrate (less accurate)</summary>
     @AVFMT_DURATION_FROM_BITRATE = 2,
+}
+
+public enum AVExifHeaderMode : int
+{
+    /// <summary>The TIFF header starts with 0x49492a00, or 0x4d4d002a. This one is used internally by FFmpeg.</summary>
+    @AV_EXIF_TIFF_HEADER = 0,
+    /// <summary>skip the TIFF header, assume little endian</summary>
+    @AV_EXIF_ASSUME_LE = 1,
+    /// <summary>skip the TIFF header, assume big endian</summary>
+    @AV_EXIF_ASSUME_BE = 2,
+    /// <summary>The first four bytes point to the actual start, then it&apos;s AV_EXIF_TIFF_HEADER</summary>
+    @AV_EXIF_T_OFF = 3,
+    /// <summary>The first six bytes contain &quot;Exif\0\0&quot;, then it&apos;s AV_EXIF_TIFF_HEADER</summary>
+    @AV_EXIF_EXIF00 = 4,
 }
 
 public enum AVFieldOrder : int
@@ -1180,6 +1201,54 @@ public enum AVHWFrameTransferDirection : int
     @AV_HWFRAME_TRANSFER_DIRECTION_FROM = 0,
     /// <summary>Transfer the data to the queried hw frame.</summary>
     @AV_HWFRAME_TRANSFER_DIRECTION_TO = 1,
+}
+
+/// <summary>@} @{</summary>
+public enum AVIAMFAmbisonicsMode : int
+{
+    @AV_IAMF_AMBISONICS_MODE_MONO = 0,
+    @AV_IAMF_AMBISONICS_MODE_PROJECTION = 1,
+}
+
+/// <summary>Immersive Audio Model and Formats related functions and defines</summary>
+public enum AVIAMFAnimationType : int
+{
+    @AV_IAMF_ANIMATION_TYPE_STEP = 0,
+    @AV_IAMF_ANIMATION_TYPE_LINEAR = 1,
+    @AV_IAMF_ANIMATION_TYPE_BEZIER = 2,
+}
+
+public enum AVIAMFAudioElementType : int
+{
+    @AV_IAMF_AUDIO_ELEMENT_TYPE_CHANNEL = 0,
+    @AV_IAMF_AUDIO_ELEMENT_TYPE_SCENE = 1,
+}
+
+/// <summary>@} @{</summary>
+public enum AVIAMFHeadphonesMode : int
+{
+    /// <summary>The referenced Audio Element shall be rendered to stereo loudspeakers.</summary>
+    @AV_IAMF_HEADPHONES_MODE_STEREO = 0,
+    /// <summary>The referenced Audio Element shall be rendered with a binaural renderer.</summary>
+    @AV_IAMF_HEADPHONES_MODE_BINAURAL = 1,
+}
+
+public enum AVIAMFParamDefinitionType : int
+{
+    /// <summary>Subblocks are of struct type AVIAMFMixGain</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN = 0,
+    /// <summary>Subblocks are of struct type AVIAMFDemixingInfo</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_DEMIXING = 1,
+    /// <summary>Subblocks are of struct type AVIAMFReconGain</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_RECON_GAIN = 2,
+}
+
+public enum AVIAMFSubmixLayoutType : int
+{
+    /// <summary>The layout follows the loudspeaker sound system convention of ITU-2051-3. AVIAMFSubmixLayout.sound_system must be set.</summary>
+    @AV_IAMF_SUBMIX_LAYOUT_TYPE_LOUDSPEAKERS = 2,
+    /// <summary>The layout is binaural.</summary>
+    @AV_IAMF_SUBMIX_LAYOUT_TYPE_BINAURAL = 3,
 }
 
 /// <summary>Different data types that can be returned via the AVIO write_data_type callback.</summary>
@@ -2076,6 +2145,24 @@ public enum AVSubtitleType : int
     @SUBTITLE_ASS = 3,
 }
 
+/// <summary>Data type identifiers for TIFF tags</summary>
+public enum AVTiffDataType : int
+{
+    @AV_TIFF_BYTE = 1,
+    @AV_TIFF_STRING = 2,
+    @AV_TIFF_SHORT = 3,
+    @AV_TIFF_LONG = 4,
+    @AV_TIFF_RATIONAL = 5,
+    @AV_TIFF_SBYTE = 6,
+    @AV_TIFF_UNDEFINED = 7,
+    @AV_TIFF_SSHORT = 8,
+    @AV_TIFF_SLONG = 9,
+    @AV_TIFF_SRATIONAL = 10,
+    @AV_TIFF_FLOAT = 11,
+    @AV_TIFF_DOUBLE = 12,
+    @AV_TIFF_IFD = 13,
+}
+
 public enum AVTimecodeFlag : int
 {
     /// <summary>timecode is drop frame</summary>
@@ -2084,6 +2171,63 @@ public enum AVTimecodeFlag : int
     @AV_TIMECODE_FLAG_24HOURSMAX = 2,
     /// <summary>negative time values are allowed</summary>
     @AV_TIMECODE_FLAG_ALLOWNEGATIVE = 4,
+}
+
+/// <summary>Flags for av_tx_init()</summary>
+public enum AVTXFlags : int
+{
+    /// <summary>Allows for in-place transformations, where input == output. May be unsupported or slower for some transform types.</summary>
+    @AV_TX_INPLACE = 1,
+    /// <summary>Relaxes alignment requirement for the in and out arrays of av_tx_fn(). May be slower with certain transform types.</summary>
+    @AV_TX_UNALIGNED = 2,
+    /// <summary>Performs a full inverse MDCT rather than leaving out samples that can be derived through symmetry. Requires an output array of &apos;len&apos; floats, rather than the usual &apos;len/2&apos; floats. Ignored for all transforms but inverse MDCTs.</summary>
+    @AV_TX_FULL_IMDCT = 4,
+    /// <summary>Perform a real to half-complex RDFT. Only the real, or imaginary coefficients will be output, depending on the flag used. Only available for forward RDFTs. Output array must have enough space to hold N complex values (regular size for a real to complex transform).</summary>
+    @AV_TX_REAL_TO_REAL = 8,
+    /// <summary>Perform a real to half-complex RDFT. Only the real, or imaginary coefficients will be output, depending on the flag used. Only available for forward RDFTs. Output array must have enough space to hold N complex values (regular size for a real to complex transform).</summary>
+    @AV_TX_REAL_TO_IMAGINARY = 16,
+}
+
+public enum AVTXType : int
+{
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_FLOAT_FFT = 0,
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_DOUBLE_FFT = 2,
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_INT32_FFT = 4,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_FLOAT_MDCT = 1,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_DOUBLE_MDCT = 3,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_INT32_MDCT = 5,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_FLOAT_RDFT = 6,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_DOUBLE_RDFT = 7,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_INT32_RDFT = 8,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_FLOAT_DCT = 9,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_DOUBLE_DCT = 10,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_INT32_DCT = 11,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_FLOAT_DCT_I = 12,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_DOUBLE_DCT_I = 13,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_INT32_DCT_I = 14,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_FLOAT_DST_I = 15,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_DOUBLE_DST_I = 16,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_INT32_DST_I = 17,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_NB = 18,
 }
 
 /// <summary>Dithering algorithms</summary>

--- a/FFmpeg.AutoGen.Abstractions/generated/Structs.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/Structs.g.cs
@@ -632,6 +632,24 @@ public unsafe partial struct AVCodecParserContext
     public int @format;
 }
 
+public unsafe partial struct AVComplexDouble
+{
+    public double @re;
+    public double @im;
+}
+
+public unsafe partial struct AVComplexFloat
+{
+    public float @re;
+    public float @im;
+}
+
+public unsafe partial struct AVComplexInt32
+{
+    public int @re;
+    public int @im;
+}
+
 public unsafe partial struct AVComponentDescriptor
 {
     /// <summary>Which of the 4 planes contains the component.</summary>
@@ -777,6 +795,59 @@ public unsafe partial struct AVDictionaryEntry
     public byte* @value;
 }
 
+/// <summary>DRM device.</summary>
+public unsafe partial struct AVDRMDeviceContext
+{
+    /// <summary>File descriptor of DRM device.</summary>
+    public int @fd;
+}
+
+/// <summary>DRM frame descriptor.</summary>
+public unsafe partial struct AVDRMFrameDescriptor
+{
+    /// <summary>Number of DRM objects making up this frame.</summary>
+    public int @nb_objects;
+    /// <summary>Array of objects making up the frame.</summary>
+    public AVDRMObjectDescriptor4 @objects;
+    /// <summary>Number of layers in the frame.</summary>
+    public int @nb_layers;
+    /// <summary>Array of layers in the frame.</summary>
+    public AVDRMLayerDescriptor4 @layers;
+}
+
+/// <summary>DRM layer descriptor.</summary>
+public unsafe partial struct AVDRMLayerDescriptor
+{
+    /// <summary>Format of the layer (DRM_FORMAT_*).</summary>
+    public uint @format;
+    /// <summary>Number of planes in the layer.</summary>
+    public int @nb_planes;
+    /// <summary>Array of planes in this layer.</summary>
+    public AVDRMPlaneDescriptor4 @planes;
+}
+
+/// <summary>DRM object descriptor.</summary>
+public unsafe partial struct AVDRMObjectDescriptor
+{
+    /// <summary>DRM PRIME fd for the object.</summary>
+    public int @fd;
+    /// <summary>Total size of the object.</summary>
+    public ulong @size;
+    /// <summary>Format modifier applied to the object (DRM_FORMAT_MOD_*).</summary>
+    public ulong @format_modifier;
+}
+
+/// <summary>DRM plane descriptor.</summary>
+public unsafe partial struct AVDRMPlaneDescriptor
+{
+    /// <summary>Index of the object containing this plane in the objects array of the enclosing frame descriptor.</summary>
+    public int @object_index;
+    /// <summary>Offset within that object of this plane.</summary>
+    public long @offset;
+    /// <summary>Pitch (linesize) of this plane.</summary>
+    public long @pitch;
+}
+
 /// <summary>This struct is allocated as AVHWDeviceContext.hwctx</summary>
 public unsafe partial struct AVDXVA2DeviceContext
 {
@@ -855,6 +926,85 @@ public unsafe partial struct AVDynamicHDRSmpte2094App5
     public ushort4x32 @gain_curve_control_points_x;
     public ushort4x32 @gain_curve_control_points_y;
     public ushort4x32 @gain_curve_control_points_theta;
+}
+
+/// <summary>This describes encryption info for a packet. This contains frame-specific info for how to decrypt the packet before passing it to the decoder.</summary>
+public unsafe partial struct AVEncryptionInfo
+{
+    /// <summary>The fourcc encryption scheme, in big-endian byte order.</summary>
+    public uint @scheme;
+    /// <summary>Only used for pattern encryption. This is the number of 16-byte blocks that are encrypted.</summary>
+    public uint @crypt_byte_block;
+    /// <summary>Only used for pattern encryption. This is the number of 16-byte blocks that are clear.</summary>
+    public uint @skip_byte_block;
+    /// <summary>The ID of the key used to encrypt the packet. This should always be 16 bytes long, but may be changed in the future.</summary>
+    public byte* @key_id;
+    public uint @key_id_size;
+    /// <summary>The initialization vector. This may have been zero-filled to be the correct block size. This should always be 16 bytes long, but may be changed in the future.</summary>
+    public byte* @iv;
+    public uint @iv_size;
+    /// <summary>An array of subsample encryption info specifying how parts of the sample are encrypted. If there are no subsamples, then the whole sample is encrypted.</summary>
+    public AVSubsampleEncryptionInfo* @subsamples;
+    public uint @subsample_count;
+}
+
+/// <summary>This describes info used to initialize an encryption key system.</summary>
+public unsafe partial struct AVEncryptionInitInfo
+{
+    /// <summary>A unique identifier for the key system this is for, can be NULL if it is not known. This should always be 16 bytes, but may change in the future.</summary>
+    public byte* @system_id;
+    public uint @system_id_size;
+    /// <summary>An array of key IDs this initialization data is for. All IDs are the same length. Can be NULL if there are no known key IDs.</summary>
+    public byte** @key_ids;
+    /// <summary>The number of key IDs.</summary>
+    public uint @num_key_ids;
+    /// <summary>The number of bytes in each key ID. This should always be 16, but may change in the future.</summary>
+    public uint @key_id_size;
+    /// <summary>Key-system specific initialization data. This data is copied directly from the file and the format depends on the specific key system. This can be NULL if there is no initialization data; in that case, there will be at least one key ID.</summary>
+    public byte* @data;
+    public uint @data_size;
+    /// <summary>An optional pointer to the next initialization info in the list.</summary>
+    public AVEncryptionInitInfo* @next;
+}
+
+public unsafe partial struct AVExifEntry
+{
+    public ushort @id;
+    public AVTiffDataType @type;
+    public uint @count;
+    public uint @ifd_offset;
+    public byte* @ifd_lead;
+    public AVExifEntry_value @value;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct AVExifEntry_value
+{
+    [FieldOffset(0)]
+    public void* @ptr;
+    [FieldOffset(0)]
+    public long* @sint;
+    [FieldOffset(0)]
+    public ulong* @uint;
+    [FieldOffset(0)]
+    public double* @dbl;
+    [FieldOffset(0)]
+    public byte* @str;
+    [FieldOffset(0)]
+    public byte* @ubytes;
+    [FieldOffset(0)]
+    public sbyte* @sbytes;
+    [FieldOffset(0)]
+    public AVRational* @rat;
+    [FieldOffset(0)]
+    public AVExifMetadata @ifd;
+}
+
+public unsafe partial struct AVExifMetadata
+{
+    public AVExifEntry* @entries;
+    public uint @count;
+    public uint @size;
 }
 
 /// <summary>Filter definition. This defines the pads a filter contains, and all the callback functions used to interact with the filter.</summary>
@@ -1414,6 +1564,167 @@ public unsafe partial struct AVHWFramesContext
     public int @width;
     /// <summary>The allocated dimensions of the frames in this pool.</summary>
     public int @height;
+}
+
+/// <summary>Information on how to combine one or more audio streams, as defined in section 3.6 of IAMF.</summary>
+public unsafe partial struct AVIAMFAudioElement
+{
+    public AVClass* @av_class;
+    public AVIAMFLayer** @layers;
+    /// <summary>Number of layers, or channel groups, in the Audio Element. There may be 6 layers at most, and for audio_element_type AV_IAMF_AUDIO_ELEMENT_TYPE_SCENE, there may be exactly 1.</summary>
+    public uint @nb_layers;
+    /// <summary>Demixing information used to reconstruct a scalable channel audio representation. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_DEMIXING.</summary>
+    public AVIAMFParamDefinition* @demixing_info;
+    /// <summary>Recon gain information used to reconstruct a scalable channel audio representation. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_RECON_GAIN.</summary>
+    public AVIAMFParamDefinition* @recon_gain_info;
+    /// <summary>Audio element type as defined in section 3.6 of IAMF.</summary>
+    public AVIAMFAudioElementType @audio_element_type;
+    /// <summary>Default weight value as defined in section 3.6 of IAMF.</summary>
+    public uint @default_w;
+}
+
+/// <summary>Demixing Info Parameter Data as defined in section 3.8.2 of IAMF.</summary>
+public unsafe partial struct AVIAMFDemixingInfo
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>Pre-defined combination of demixing parameters.</summary>
+    public uint @dmixp_mode;
+}
+
+/// <summary>A layer defining a Channel Layout in the Audio Element.</summary>
+public unsafe partial struct AVIAMFLayer
+{
+    public AVClass* @av_class;
+    public AVChannelLayout @ch_layout;
+    /// <summary>A bitmask which may contain a combination of AV_IAMF_LAYER_FLAG_* flags.</summary>
+    public uint @flags;
+    /// <summary>Output gain channel flags as defined in section 3.6.2 of IAMF.</summary>
+    public uint @output_gain_flags;
+    /// <summary>Output gain as defined in section 3.6.2 of IAMF.</summary>
+    public AVRational @output_gain;
+    /// <summary>Ambisonics mode as defined in section 3.6.3 of IAMF.</summary>
+    public AVIAMFAmbisonicsMode @ambisonics_mode;
+    /// <summary>Demixing matrix as defined in section 3.6.3 of IAMF.</summary>
+    public AVRational* @demixing_matrix;
+    /// <summary>The length of the Demixing matrix array. Must be ch_layout.nb_channels multiplied by the sum of the amount of streams in the group plus the amount of streams in the group that are stereo.</summary>
+    public uint @nb_demixing_matrix;
+}
+
+/// <summary>Mix Gain Parameter Data as defined in section 3.8.1 of IAMF.</summary>
+public unsafe partial struct AVIAMFMixGain
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>The type of animation applied to the parameter values.</summary>
+    public AVIAMFAnimationType @animation_type;
+    /// <summary>Parameter value that is applied at the start of the subblock. Applies to all defined Animation Types.</summary>
+    public AVRational @start_point_value;
+    /// <summary>Parameter value that is applied at the end of the subblock. Applies only to AV_IAMF_ANIMATION_TYPE_LINEAR and AV_IAMF_ANIMATION_TYPE_BEZIER Animation Types.</summary>
+    public AVRational @end_point_value;
+    /// <summary>Parameter value of the middle control point of a quadratic Bezier curve, i.e., its y-axis value. Applies only to AV_IAMF_ANIMATION_TYPE_BEZIER Animation Type.</summary>
+    public AVRational @control_point_value;
+    /// <summary>Parameter value of the time of the middle control point of a quadratic Bezier curve, i.e., its x-axis value. Applies only to AV_IAMF_ANIMATION_TYPE_BEZIER Animation Type.</summary>
+    public AVRational @control_point_relative_time;
+}
+
+/// <summary>Information on how to render and mix one or more AVIAMFAudioElement to generate the final audio output, as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFMixPresentation
+{
+    public AVClass* @av_class;
+    /// <summary>Array of submixes.</summary>
+    public AVIAMFSubmix** @submixes;
+    /// <summary>Number of submixes in the presentation.</summary>
+    public uint @nb_submixes;
+    /// <summary>A dictionary of strings describing the mix in different languages. Must have the same amount of entries as every AVIAMFSubmixElement.annotations &quot;Submix element annotations&quot;, stored in the same order, and with the same key strings.</summary>
+    public AVDictionary* @annotations;
+}
+
+/// <summary>Parameters as defined in section 3.6.1 of IAMF.</summary>
+public unsafe partial struct AVIAMFParamDefinition
+{
+    public AVClass* @av_class;
+    /// <summary>Offset in bytes from the start of this struct, at which the subblocks array is located.</summary>
+    public ulong @subblocks_offset;
+    /// <summary>Size in bytes of each element in the subblocks array.</summary>
+    public ulong @subblock_size;
+    /// <summary>Number of subblocks in the array.</summary>
+    public uint @nb_subblocks;
+    /// <summary>Parameters type. Determines the type of the subblock elements.</summary>
+    public AVIAMFParamDefinitionType @type;
+    /// <summary>Identifier for the parameter substream.</summary>
+    public uint @parameter_id;
+    /// <summary>Sample rate for the parameter substream. It must not be 0.</summary>
+    public uint @parameter_rate;
+    /// <summary>The accumulated duration of all blocks in this parameter definition, in units of 1 / parameter_rate.</summary>
+    public uint @duration;
+    /// <summary>The duration of every subblock in the case where all subblocks, with the optional exception of the last subblock, have equal durations.</summary>
+    public uint @constant_subblock_duration;
+}
+
+/// <summary>Recon Gain Info Parameter Data as defined in section 3.8.3 of IAMF.</summary>
+public unsafe partial struct AVIAMFReconGain
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>Array of gain values to be applied to each channel for each layer defined in the Audio Element referencing the parent Parameter Definition. Values for layers where the AV_IAMF_LAYER_FLAG_RECON_GAIN flag is not set are undefined.</summary>
+    public byte6x12 @recon_gain;
+}
+
+/// <summary>Submix layout as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmix
+{
+    public AVClass* @av_class;
+    /// <summary>Array of submix elements.</summary>
+    public AVIAMFSubmixElement** @elements;
+    /// <summary>Number of elements in the submix.</summary>
+    public uint @nb_elements;
+    /// <summary>Array of submix layouts.</summary>
+    public AVIAMFSubmixLayout** @layouts;
+    /// <summary>Number of layouts in the submix.</summary>
+    public uint @nb_layouts;
+    /// <summary>Information required for post-processing the mixed audio signal to generate the audio signal for playback. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN.</summary>
+    public AVIAMFParamDefinition* @output_mix_config;
+    /// <summary>Default mix gain value to apply when there are no AVIAMFParamDefinition with output_mix_config &quot;output_mix_config&apos;s&quot; AVIAMFParamDefinition.parameter_id &quot;parameter_id&quot; available for a given audio frame.</summary>
+    public AVRational @default_mix_gain;
+}
+
+/// <summary>Submix element as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmixElement
+{
+    public AVClass* @av_class;
+    /// <summary>The id of the Audio Element this submix element references.</summary>
+    public uint @audio_element_id;
+    /// <summary>Information required required for applying any processing to the referenced and rendered Audio Element before being summed with other processed Audio Elements. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN.</summary>
+    public AVIAMFParamDefinition* @element_mix_config;
+    /// <summary>Default mix gain value to apply when there are no AVIAMFParamDefinition with element_mix_config &quot;element_mix_config&apos;s&quot; AVIAMFParamDefinition.parameter_id &quot;parameter_id&quot; available for a given audio frame.</summary>
+    public AVRational @default_mix_gain;
+    /// <summary>A value that indicates whether the referenced channel-based Audio Element shall be rendered to stereo loudspeakers or spatialized with a binaural renderer when played back on headphones. If the Audio Element is not of AVIAMFAudioElement.audio_element_type &quot;type&quot; AV_IAMF_AUDIO_ELEMENT_TYPE_CHANNEL, then this field is undefined.</summary>
+    public AVIAMFHeadphonesMode @headphones_rendering_mode;
+    /// <summary>A dictionary of strings describing the submix in different languages. Must have the same amount of entries as AVIAMFMixPresentation.annotations &quot;the mix&apos;s annotations&quot;, stored in the same order, and with the same key strings.</summary>
+    public AVDictionary* @annotations;
+}
+
+/// <summary>Submix layout as defined in section 3.7.6 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmixLayout
+{
+    public AVClass* @av_class;
+    public AVIAMFSubmixLayoutType @layout_type;
+    /// <summary>Channel layout matching one of Sound Systems A to J of ITU-2051-3, plus 7.1.2ch, 3.1.2ch, and binaural. If layout_type is not AV_IAMF_SUBMIX_LAYOUT_TYPE_LOUDSPEAKERS or AV_IAMF_SUBMIX_LAYOUT_TYPE_BINAURAL, this field is undefined.</summary>
+    public AVChannelLayout @sound_system;
+    /// <summary>The program integrated loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @integrated_loudness;
+    /// <summary>The digital (sampled) peak value of the audio signal, as defined in ITU-1770-4.</summary>
+    public AVRational @digital_peak;
+    /// <summary>The true peak of the audio signal, as defined in ITU-1770-4.</summary>
+    public AVRational @true_peak;
+    /// <summary>The Dialogue loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @dialogue_anchored_loudness;
+    /// <summary>The Album loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @album_anchored_loudness;
 }
 
 public unsafe partial struct AVIndexEntry
@@ -1984,6 +2295,14 @@ public unsafe partial struct AVStreamGroupTREF
     public uint @metadata_index;
 }
 
+public unsafe partial struct AVSubsampleEncryptionInfo
+{
+    /// <summary>The number of bytes that are clear.</summary>
+    public uint @bytes_of_clear_data;
+    /// <summary>The number of bytes that are protected. If using pattern encryption, the pattern applies to only the protected bytes; if not using pattern encryption, all these bytes are encrypted.</summary>
+    public uint @bytes_of_protected_data;
+}
+
 public unsafe partial struct AVSubtitle
 {
     public ushort @format;
@@ -2525,6 +2844,19 @@ public unsafe partial struct SwsVector
     public int @length;
 }
 
+public unsafe partial struct tm
+{
+    public int @tm_sec;
+    public int @tm_min;
+    public int @tm_hour;
+    public int @tm_mday;
+    public int @tm_mon;
+    public int @tm_year;
+    public int @tm_wday;
+    public int @tm_yday;
+    public int @tm_isdst;
+}
+
 /// <summary>Context for an Audio FIFO Buffer.</summary>
 /// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVAudioFifo
@@ -2577,6 +2909,11 @@ public unsafe partial struct AVDictionary
 }
 
 /// <remarks>This struct is incomplete.</remarks>
+public unsafe partial struct AVExpr
+{
+}
+
+/// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVFilterChannelLayouts
 {
 }
@@ -2592,16 +2929,6 @@ public unsafe partial struct AVFilterPad
 }
 
 /// <remarks>This struct is incomplete.</remarks>
-public unsafe partial struct AVIAMFAudioElement
-{
-}
-
-/// <remarks>This struct is incomplete.</remarks>
-public unsafe partial struct AVIAMFMixPresentation
-{
-}
-
-/// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVIODirContext
 {
 }
@@ -2609,6 +2936,11 @@ public unsafe partial struct AVIODirContext
 /// <summary>Low-complexity tree container</summary>
 /// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVTreeNode
+{
+}
+
+/// <remarks>This struct is incomplete.</remarks>
+public unsafe partial struct AVTXContext
 {
 }
 

--- a/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.functions.facade.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.functions.facade.g.cs
@@ -37,6 +37,10 @@ public static unsafe partial class ffmpeg
     /// <returns>&gt;0 (read size) if OK, AVERROR_xxx otherwise, previous data will not be lost even if an error occurs.</returns>
     public static int av_append_packet(AVIOContext* @s, AVPacket* @pkt, int @size) => vectors.av_append_packet(@s, @pkt, @size);
     
+    /// <summary>Assert that floating point operations can be executed.</summary>
+    [Obsolete("without replacement")]
+    public static void av_assert0_fpu() => vectors.av_assert0_fpu();
+    
     /// <summary>Allocate an AVAudioFifo.</summary>
     /// <param name="sample_fmt">sample format</param>
     /// <param name="channels">number of channels</param>
@@ -781,6 +785,132 @@ public static unsafe partial class ffmpeg
     /// <returns>Pointer to the data of the element to copy in the newly allocated space</returns>
     public static void* av_dynarray2_add(void** @tab_ptr, int* @nb_ptr, ulong @elem_size, byte* @elem_data) => vectors.av_dynarray2_add(@tab_ptr, @nb_ptr, @elem_size, @elem_data);
     
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    public static byte* av_encryption_info_add_side_data(AVEncryptionInfo* @info, ulong* @side_data_size) => vectors.av_encryption_info_add_side_data(@info, @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure and sub-pointers to hold the given number of subsamples. This will allocate pointers for the key ID, IV, and subsample entries, set the size members, and zero-initialize the rest.</summary>
+    /// <param name="subsample_count">The number of subsamples.</param>
+    /// <param name="key_id_size">The number of bytes in the key ID, should be 16.</param>
+    /// <param name="iv_size">The number of bytes in the IV, should be 16.</param>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_alloc(uint @subsample_count, uint @key_id_size, uint @iv_size) => vectors.av_encryption_info_alloc(@subsample_count, @key_id_size, @iv_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure with a copy of the given data.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_clone(AVEncryptionInfo* @info) => vectors.av_encryption_info_clone(@info);
+    
+    /// <summary>Frees the given encryption info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    public static void av_encryption_info_free(AVEncryptionInfo* @info) => vectors.av_encryption_info_free(@info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInfo that is contained in the given side data. The resulting object should be passed to av_encryption_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_get_side_data(byte* @side_data, ulong @side_data_size) => vectors.av_encryption_info_get_side_data(@side_data, @side_data_size);
+    
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption init info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    public static byte* av_encryption_init_info_add_side_data(AVEncryptionInitInfo* @info, ulong* @side_data_size) => vectors.av_encryption_init_info_add_side_data(@info, @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInitInfo structure and sub-pointers to hold the given sizes. This will allocate pointers and set all the fields.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInitInfo* av_encryption_init_info_alloc(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size) => vectors.av_encryption_init_info_alloc(@system_id_size, @num_key_ids, @key_id_size, @data_size);
+    
+    /// <summary>Frees the given encryption init info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    public static void av_encryption_init_info_free(AVEncryptionInitInfo* @info) => vectors.av_encryption_init_info_free(@info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInitInfo that is contained in the given side data. The resulting object should be passed to av_encryption_init_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInitInfo* av_encryption_init_info_get_side_data(byte* @side_data, ulong @side_data_size) => vectors.av_encryption_init_info_get_side_data(@side_data, @side_data_size);
+    
+    /// <summary>Allocates a duplicate of the provided EXIF metadata struct. The caller owns the duplicate and must free it with av_exif_free. Returns NULL if the duplication process failed.</summary>
+    public static AVExifMetadata* av_exif_clone_ifd(AVExifMetadata* @ifd) => vectors.av_exif_clone_ifd(@ifd);
+    
+    /// <summary>Frees all resources associated with the given EXIF metadata struct. Does not free the pointer passed itself, in case it is stack-allocated. The pointer passed to this function must be freed by the caller, if it is heap-allocated. Passing NULL is permitted.</summary>
+    public static void av_exif_free(AVExifMetadata* @ifd) => vectors.av_exif_free(@ifd);
+    
+    /// <summary>Get an entry with the tagged ID from the EXIF metadata struct. A pointer to the entry will be written into *value.</summary>
+    public static int av_exif_get_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value) => vectors.av_exif_get_entry(@logctx, @ifd, @id, @flags, @value);
+    
+    /// <summary>Retrieves the tag ID associated with the provided tag string name. If the tag name is unknown, a negative number is returned. Otherwise it always fits inside a uint16_t integer.</summary>
+    public static int av_exif_get_tag_id(string @name) => vectors.av_exif_get_tag_id(@name);
+    
+    /// <summary>Retrieves the tag name associated with the provided tag ID. If the tag ID is unknown, NULL is returned.</summary>
+    public static string av_exif_get_tag_name(ushort @id) => vectors.av_exif_get_tag_name(@id);
+    
+    /// <summary>Recursively reads all tags from the IFD and stores them in the provided metadata dictionary.</summary>
+    public static int av_exif_ifd_to_dict(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata) => vectors.av_exif_ifd_to_dict(@logctx, @ifd, @metadata);
+    
+    /// <summary>Convert a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX into an orientation constant used by EXIF&apos;s orientation tag.</summary>
+    public static int av_exif_matrix_to_orientation(int* @matrix) => vectors.av_exif_matrix_to_orientation(@matrix);
+    
+    /// <summary>Convert an orientation constant used by EXIF&apos;s orientation tag into a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX.</summary>
+    public static int av_exif_orientation_to_matrix(int* @matrix, int @orientation) => vectors.av_exif_orientation_to_matrix(@matrix, @orientation);
+    
+    /// <summary>Decodes the EXIF data provided in the buffer and writes it into the struct *ifd. If this function succeeds, the IFD is owned by the caller and must be cleared after use by calling av_exif_free(); If this function fails and returns a negative value, it will call av_exif_free(ifd) before returning.</summary>
+    public static int av_exif_parse_buffer(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode) => vectors.av_exif_parse_buffer(@logctx, @data, @size, @ifd, @header_mode);
+    
+    /// <summary>Remove an entry from the provided EXIF metadata struct.</summary>
+    public static int av_exif_remove_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags) => vectors.av_exif_remove_entry(@logctx, @ifd, @id, @flags);
+    
+    /// <summary>Add an entry to the provided EXIF metadata struct. If one already exists with the provided ID, it will set the existing one to have the other information provided. Otherwise, it will allocate a new entry.</summary>
+    public static int av_exif_set_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value) => vectors.av_exif_set_entry(@logctx, @ifd, @id, @type, @count, @ifd_lead, @ifd_offset, @value);
+    
+    /// <summary>Allocates a buffer using av_malloc of an appropriate size and writes the EXIF data represented by ifd into that buffer.</summary>
+    public static int av_exif_write(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode) => vectors.av_exif_write(@logctx, @ifd, @buffer, @header_mode);
+    
+    /// <summary>Track the presence of user provided functions and their number of occurrences in a parsed expression.</summary>
+    /// <param name="e">the AVExpr to track user provided functions in</param>
+    /// <param name="counter">a zero-initialized array where the count of each function will be stored if you passed 5 functions with 2 arguments to av_expr_parse() then for arg=2 this will use up to 5 entries.</param>
+    /// <param name="size">size of array</param>
+    /// <param name="arg">number of arguments the counted functions have</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    public static int av_expr_count_func(AVExpr* @e, uint* @counter, int @size, int @arg) => vectors.av_expr_count_func(@e, @counter, @size, @arg);
+    
+    /// <summary>Track the presence of variables and their number of occurrences in a parsed expression</summary>
+    /// <param name="e">the AVExpr to track variables in</param>
+    /// <param name="counter">a zero-initialized array where the count of each variable will be stored</param>
+    /// <param name="size">size of array</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    public static int av_expr_count_vars(AVExpr* @e, uint* @counter, int @size) => vectors.av_expr_count_vars(@e, @counter, @size);
+    
+    /// <summary>Evaluate a previously parsed expression.</summary>
+    /// <param name="e">the AVExpr to evaluate</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from av_expr_parse() const_names</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <returns>the value of the expression</returns>
+    public static double av_expr_eval(AVExpr* @e, double* @const_values, void* @opaque) => vectors.av_expr_eval(@e, @const_values, @opaque);
+    
+    /// <summary>Free a parsed expression previously created with av_expr_parse().</summary>
+    public static void av_expr_free(AVExpr* @e) => vectors.av_expr_free(@e);
+    
+    /// <summary>Parse an expression.</summary>
+    /// <param name="expr">a pointer where is put an AVExpr containing the parsed value in case of successful parsing, or NULL otherwise. The pointed to AVExpr must be freed with av_expr_free() by the user when it is not needed anymore.</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_expr_parse(AVExpr** @expr, string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx) => vectors.av_expr_parse(@expr, @s, @const_names, @func1_names, @funcs1, @func2_names, @funcs2, @log_offset, @log_ctx);
+    
+    /// <summary>Parse and evaluate an expression. Note, this is significantly slower than av_expr_eval().</summary>
+    /// <param name="res">a pointer to a double where is put the result value of the expression, or NAN in case of error</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from const_names</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_expr_parse_and_eval(double* @res, string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx) => vectors.av_expr_parse_and_eval(@res, @s, @const_names, @const_values, @func1_names, @funcs1, @func2_names, @funcs2, @opaque, @log_offset, @log_ctx);
+    
     /// <summary>Allocate a buffer, reusing the given one if large enough.</summary>
     /// <param name="ptr">Pointer to pointer to an already allocated buffer. `*ptr` will be overwritten with pointer to new buffer on success or `NULL` on failure</param>
     /// <param name="size">Pointer to the size of buffer `*ptr`. `*size` is updated to the new allocated size, in particular 0 in case of failure.</param>
@@ -847,6 +977,9 @@ public static unsafe partial class ffmpeg
     public static int av_find_best_stream(AVFormatContext* @ic, AVMediaType @type, int @wanted_stream_nb, int @related_stream, AVCodec** @decoder_ret, int @flags) => vectors.av_find_best_stream(@ic, @type, @wanted_stream_nb, @related_stream, @decoder_ret, @flags);
     
     public static int av_find_default_stream_index(AVFormatContext* @s) => vectors.av_find_default_stream_index(@s);
+    
+    /// <summary>Attempt to find a specific tag in a URL.</summary>
+    public static int av_find_info_tag(byte* @arg, int @arg_size, string @tag1, string @info) => vectors.av_find_info_tag(@arg, @arg_size, @tag1, @info);
     
     /// <summary>Find AVInputFormat based on the short name of the input format.</summary>
     public static AVInputFormat* av_find_input_format(string @short_name) => vectors.av_find_input_format(@short_name);
@@ -1065,6 +1198,12 @@ public static unsafe partial class ffmpeg
     /// <param name="flags">AV_FRAME_FILENAME_FLAGS_*</param>
     /// <returns>0 if OK, -1 on format error</returns>
     public static int av_get_frame_filename2(byte* @buf, int @buf_size, string @path, int @number, int @flags) => vectors.av_get_frame_filename2(@buf, @buf_size, @path, @number, @flags);
+    
+    /// <summary>Get the name of a color from the internal table of hard-coded named colors.</summary>
+    /// <param name="color_idx">index of the requested color, starting from 0</param>
+    /// <param name="rgb">if not NULL, will point to a 3-elements array with the color value in RGB</param>
+    /// <returns>the color name string or NULL if color_idx is not in the array</returns>
+    public static string av_get_known_color_name(int @color_idx, byte** @rgb) => vectors.av_get_known_color_name(@color_idx, @rgb);
     
     /// <summary>Return a string describing the media_type enum, NULL if media_type is unknown.</summary>
     public static string av_get_media_type_string(AVMediaType @media_type) => vectors.av_get_media_type_string(@media_type);
@@ -1308,6 +1447,45 @@ public static unsafe partial class ffmpeg
     /// <param name="flags">currently unused, should be set to zero</param>
     /// <returns>0 on success, a negative AVERROR code on failure.</returns>
     public static int av_hwframe_transfer_get_formats(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags) => vectors.av_hwframe_transfer_get_formats(@hwframe_ctx, @dir, @formats, @flags);
+    
+    /// <summary>Allocate a layer and add it to a given AVIAMFAudioElement. It is freed by av_iamf_audio_element_free() alongside the rest of the parent AVIAMFAudioElement.</summary>
+    /// <returns>a pointer to the allocated layer.</returns>
+    public static AVIAMFLayer* av_iamf_audio_element_add_layer(AVIAMFAudioElement* @audio_element) => vectors.av_iamf_audio_element_add_layer(@audio_element);
+    
+    /// <summary>Allocates a AVIAMFAudioElement, and initializes its fields with default values. No layers are allocated. Must be freed with av_iamf_audio_element_free().</summary>
+    public static AVIAMFAudioElement* av_iamf_audio_element_alloc() => vectors.av_iamf_audio_element_alloc();
+    
+    /// <summary>Free an AVIAMFAudioElement and all its contents.</summary>
+    /// <param name="audio_element">pointer to pointer to an allocated AVIAMFAudioElement. upon return, *audio_element will be set to NULL.</param>
+    public static void av_iamf_audio_element_free(AVIAMFAudioElement** @audio_element) => vectors.av_iamf_audio_element_free(@audio_element);
+    
+    public static AVClass* av_iamf_audio_element_get_class() => vectors.av_iamf_audio_element_get_class();
+    
+    /// <summary>Allocate a submix and add it to a given AVIAMFMixPresentation. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFMixPresentation.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmix* av_iamf_mix_presentation_add_submix(AVIAMFMixPresentation* @mix_presentation) => vectors.av_iamf_mix_presentation_add_submix(@mix_presentation);
+    
+    /// <summary>Allocates a AVIAMFMixPresentation, and initializes its fields with default values. No submixes are allocated. Must be freed with av_iamf_mix_presentation_free().</summary>
+    public static AVIAMFMixPresentation* av_iamf_mix_presentation_alloc() => vectors.av_iamf_mix_presentation_alloc();
+    
+    /// <summary>Free an AVIAMFMixPresentation and all its contents.</summary>
+    /// <param name="mix_presentation">pointer to pointer to an allocated AVIAMFMixPresentation. upon return, *mix_presentation will be set to NULL.</param>
+    public static void av_iamf_mix_presentation_free(AVIAMFMixPresentation** @mix_presentation) => vectors.av_iamf_mix_presentation_free(@mix_presentation);
+    
+    public static AVClass* av_iamf_mix_presentation_get_class() => vectors.av_iamf_mix_presentation_get_class();
+    
+    /// <summary>Allocates memory for AVIAMFParamDefinition, plus an array of {</summary>
+    public static AVIAMFParamDefinition* av_iamf_param_definition_alloc(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size) => vectors.av_iamf_param_definition_alloc(@type, @nb_subblocks, @size);
+    
+    public static AVClass* av_iamf_param_definition_get_class() => vectors.av_iamf_param_definition_get_class();
+    
+    /// <summary>Allocate a submix element and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmixElement* av_iamf_submix_add_element(AVIAMFSubmix* @submix) => vectors.av_iamf_submix_add_element(@submix);
+    
+    /// <summary>Allocate a submix layout and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmixLayout* av_iamf_submix_add_layout(AVIAMFSubmix* @submix) => vectors.av_iamf_submix_add_layout(@submix);
     
     /// <summary>Allocate an image with size w and h and pixel format pix_fmt, and fill pointers and linesizes accordingly. The allocated image buffer has to be freed by using av_freep(&amp;pointers[0]).</summary>
     /// <param name="pointers">array to be filled with the pointer for each image plane</param>
@@ -1998,9 +2176,46 @@ public static unsafe partial class ffmpeg
     /// <param name="pkt">The packet to be unreferenced.</param>
     public static void av_packet_unref(AVPacket* @pkt) => vectors.av_packet_unref(@pkt);
     
+    /// <summary>Put the RGBA values that correspond to color_string in rgba_color.</summary>
+    /// <param name="rgba_color">4-elements array of uint8_t values, where the respective red, green, blue and alpha component values are written.</param>
+    /// <param name="color_string">a string specifying a color. It can be the name of a color (case insensitive match) or a [0x|#]RRGGBB[AA] sequence, possibly followed by &quot; &quot; and a string representing the alpha component. The alpha component may be a string composed by &quot;0x&quot; followed by an hexadecimal number or a decimal number between 0.0 and 1.0, which represents the opacity value (0x00/0.0 means completely transparent, 0xff/1.0 completely opaque). If the alpha component is not specified then 0xff is assumed. The string &quot;random&quot; will result in a random color.</param>
+    /// <param name="slen">length of the initial part of color_string containing the color. It can be set to -1 if color_string is a null terminated string containing nothing else than the color.</param>
+    /// <param name="log_ctx">a pointer to an arbitrary struct of which the first field is a pointer to an AVClass struct (used for av_log()). Can be NULL.</param>
+    /// <returns>&gt;= 0 in case of success, a negative value in case of failure (for example if color_string cannot be parsed).</returns>
+    public static int av_parse_color(byte* @rgba_color, string @color_string, int @slen, void* @log_ctx) => vectors.av_parse_color(@rgba_color, @color_string, @slen, @log_ctx);
+    
     /// <summary>Parse CPU caps from a string and update the given AV_CPU_* flags based on that.</summary>
     /// <returns>negative on error.</returns>
     public static int av_parse_cpu_caps(uint* @flags, string @s) => vectors.av_parse_cpu_caps(@flags, @s);
+    
+    /// <summary>Parse str and store the parsed ratio in q.</summary>
+    /// <param name="q">pointer to the AVRational which will contain the ratio</param>
+    /// <param name="str">the string to parse: it has to be a string in the format num:den, a float number or an expression</param>
+    /// <param name="max">the maximum allowed numerator and denominator</param>
+    /// <param name="log_offset">log level offset which is applied to the log level of log_ctx</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_ratio(AVRational* @q, string @str, int @max, int @log_offset, void* @log_ctx) => vectors.av_parse_ratio(@q, @str, @max, @log_offset, @log_ctx);
+    
+    /// <summary>Parse timestr and return in *time a corresponding number of microseconds.</summary>
+    /// <param name="timeval">puts here the number of microseconds corresponding to the string in timestr. If the string represents a duration, it is the number of microseconds contained in the time interval.  If the string is a date, is the number of microseconds since 1st of January, 1970 up to the time of the parsed date.  If timestr cannot be successfully parsed, set *time to INT64_MIN.</param>
+    /// <param name="timestr">a string representing a date or a duration. - If a date the syntax is:</param>
+    /// <param name="duration">flag which tells how to interpret timestr, if not zero timestr is interpreted as a duration, otherwise as a date</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_parse_time(long* @timeval, string @timestr, int @duration) => vectors.av_parse_time(@timeval, @timestr, @duration);
+    
+    /// <summary>Parse str and store the detected values in *rate.</summary>
+    /// <param name="rate">pointer to the AVRational which will contain the detected frame rate</param>
+    /// <param name="str">the string to parse: it has to be a string in the format rate_num / rate_den, a float number or a valid video rate abbreviation</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_video_rate(AVRational* @rate, string @str) => vectors.av_parse_video_rate(@rate, @str);
+    
+    /// <summary>Parse str and put in width_ptr and height_ptr the detected values.</summary>
+    /// <param name="width_ptr">pointer to the variable which will contain the detected width value</param>
+    /// <param name="height_ptr">pointer to the variable which will contain the detected height value</param>
+    /// <param name="str">the string to parse: it has to be a string in the format width x height or a valid video size abbreviation.</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_video_size(int* @width_ptr, int* @height_ptr, string @str) => vectors.av_parse_video_size(@width_ptr, @height_ptr, @str);
     
     public static void av_parser_close(AVCodecParserContext* @s) => vectors.av_parser_close(@s);
     
@@ -2293,6 +2508,10 @@ public static unsafe partial class ffmpeg
     /// <returns>0 on success, AVERROR(EINVAL) on overflow</returns>
     public static int av_size_mult(ulong @a, ulong @b, ulong* @r) => vectors.av_size_mult(@a, @b, @r);
     
+    /// <summary>Simplified version of strptime</summary>
+    /// <returns>a pointer to the first character not processed in this function call. In case the input string contains more characters than required by the format string the return value points right after the last consumed input character. In case the whole input string is consumed the return value points to the null byte at the end of the string. On failure NULL is returned.</returns>
+    public static byte* av_small_strptime(string @p, string @fmt, tm* @dt) => vectors.av_small_strptime(@p, @fmt, @dt);
+    
     /// <summary>Duplicate a string.</summary>
     /// <param name="s">String to be duplicated</param>
     /// <returns>Pointer to a newly-allocated string containing a copy of `s` or `NULL` if the string cannot be allocated</returns>
@@ -2318,6 +2537,11 @@ public static unsafe partial class ffmpeg
     /// <param name="len">Maximum length of the resulting string (not counting the terminating byte)</param>
     /// <returns>Pointer to a newly-allocated string containing a substring of `s` or `NULL` if the string cannot be allocated</returns>
     public static byte* av_strndup(string @s, ulong @len) => vectors.av_strndup(@s, @len);
+    
+    /// <summary>Parse the string in numstr and return its value as a double. If the string is empty, contains only whitespaces, or does not contain an initial substring that has the expected syntax for a floating-point number, no conversion is performed. In this case, returns a value of zero and the value returned in tail is the value of numstr.</summary>
+    /// <param name="numstr">a string representing a number, may contain one of the International System number postfixes, for example &apos;K&apos;, &apos;M&apos;, &apos;G&apos;. If &apos;i&apos; is appended after the postfix, powers of 2 are used instead of powers of 10. The &apos;B&apos; postfix multiplies the value by 8, and can be appended after another postfix or used alone. This allows using for example &apos;KB&apos;, &apos;MiB&apos;, &apos;G&apos; and &apos;B&apos; as postfix.</param>
+    /// <param name="tail">if non-NULL puts here the pointer to the char next after the last parsed character</param>
+    public static double av_strtod(string @numstr, byte** @tail) => vectors.av_strtod(@numstr, @tail);
     
     /// <summary>Subtract one rational from another.</summary>
     /// <param name="b">First rational</param>
@@ -2409,6 +2633,9 @@ public static unsafe partial class ffmpeg
     /// <returns>the buf parameter</returns>
     public static byte* av_timecode_make_string(AVTimecode* @tc, byte* @buf, int @framenum) => vectors.av_timecode_make_string(@tc, @buf, @framenum);
     
+    /// <summary>Convert the decomposed UTC time in tm to a time_t value.</summary>
+    public static long av_timegm(tm* @tm) => vectors.av_timegm(@tm);
+    
     public static void av_tree_destroy(AVTreeNode* @t) => vectors.av_tree_destroy(@t);
     
     /// <summary>Apply enu(opaque, &amp;elem) to all the elements in the tree in a given range.</summary>
@@ -2432,6 +2659,20 @@ public static unsafe partial class ffmpeg
     
     /// <summary>Allocate an AVTreeNode.</summary>
     public static AVTreeNode* av_tree_node_alloc() => vectors.av_tree_node_alloc();
+    
+    /// <summary>Initialize a transform context with the given configuration (i)MDCTs with an odd length are currently not supported.</summary>
+    /// <param name="ctx">the context to allocate, will be NULL on error</param>
+    /// <param name="tx">pointer to the transform function pointer to set</param>
+    /// <param name="type">type the type of transform</param>
+    /// <param name="inv">whether to do an inverse or a forward transform</param>
+    /// <param name="len">the size of the transform in samples</param>
+    /// <param name="scale">pointer to the value to scale the output if supported by type</param>
+    /// <param name="flags">a bitmask of AVTXFlags or 0</param>
+    /// <returns>0 on success, negative error code on failure</returns>
+    public static int av_tx_init(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags) => vectors.av_tx_init(@ctx, @tx, @type, @inv, @len, @scale, @flags);
+    
+    /// <summary>Frees a context and sets *ctx to NULL, does nothing when *ctx == NULL.</summary>
+    public static void av_tx_uninit(AVTXContext** @ctx) => vectors.av_tx_uninit(@ctx);
     
     /// <summary>Split a URL string into components.</summary>
     /// <param name="proto">the buffer for the protocol</param>

--- a/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.functions.inline.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.functions.inline.g.cs
@@ -192,6 +192,16 @@ public static unsafe partial class ffmpeg
     }
     // original body hash: nxiyu/BnkvF9Z/fWwpii6qfquOeLA/wdeiuxyQQxS4E=
     
+    /// <summary>Get the subblock at the specified {</summary>
+    public static void* av_iamf_param_definition_get_subblock(AVIAMFParamDefinition* @par, uint @idx)
+    {
+        // The C body asserts with av_assert0 and calls abort(); throwing carries the same
+        // meaning to a managed caller.
+        if (idx >= par->nb_subblocks) throw new IndexOutOfRangeException(nameof(idx));
+        return (byte*)par + par->subblocks_offset + idx * par->subblock_size;
+    }
+    // original body hash: px1Hq8gB6XEAsEXGs8XH6gMabrGX4d2QIZ9NUwafgjk=
+    
     /// <summary>Wrapper around av_image_copy() to workaround the limitation that the conversion from uint8_t * const * to const uint8_t * const * is not performed automatically in C.</summary>
     public static void av_image_copy2(ref byte_ptr4 @dst_data, in int4 @dst_linesizes, ref byte_ptr4 @src_data, in int4 @src_linesizes, AVPixelFormat @pix_fmt, int @width, int @height)
     {

--- a/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.macros.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/ffmpeg.macros.g.cs
@@ -8,6 +8,11 @@ public static unsafe partial class ffmpeg
     // public static av_alias = __attribute__((may_alias));
     // public static av_alloc_size = (...);
     // public static av_always_inline = __attribute__((always_inline)) inline;
+    // public static av_assert0 = (cond) do {                                           if (!(cond)) {                                                      av_log(NULL, AV_LOG_PANIC, "Assertion %s failed at %s:%d\n",    AV_STRINGIFY(cond), __FILE__, __LINE__);                 abort();                                                        }                                                                   } while (0);
+    // public static av_assert1 = (cond)((void)(0x0));
+    // public static av_assert2 = (cond)((void)(0x0));
+    // public static av_assert2_fpu = () ((void)0);
+    // public static av_assume = (cond)(av_assert0(cond));
     /// <summary>AV_BUFFER_FLAG_READONLY = (1 &lt;&lt; 0)</summary>
     public const int AV_BUFFER_FLAG_READONLY = 0x1 << 0x0;
     /// <summary>AV_BUFFERSINK_FLAG_NO_REQUEST = 0x2</summary>
@@ -566,6 +571,8 @@ public static unsafe partial class ffmpeg
     // public static av_err2str = (errnum) av_make_error_string((char[AV_ERROR_MAX_STRING_SIZE]){0}, AV_ERROR_MAX_STRING_SIZE, errnum);
     /// <summary>AV_ERROR_MAX_STRING_SIZE = 64</summary>
     public const int AV_ERROR_MAX_STRING_SIZE = 0x40;
+    /// <summary>AV_EXIF_FLAG_RECURSIVE = 0x1 &lt;&lt; 0x0</summary>
+    public const int AV_EXIF_FLAG_RECURSIVE = 0x1 << 0x0;
     // public static av_extern_inline = inline;
     // public static av_fallthrough = __attribute__((fallthrough));
     /// <summary>AV_FDEBUG_ID3V2 = 0x0002</summary>
@@ -624,6 +631,8 @@ public static unsafe partial class ffmpeg
     public const int AV_HWACCEL_FLAG_IGNORE_LEVEL = 0x1 << 0x0;
     /// <summary>AV_HWACCEL_FLAG_UNSAFE_OUTPUT = 0x1 &lt;&lt; 0x3</summary>
     public const int AV_HWACCEL_FLAG_UNSAFE_OUTPUT = 0x1 << 0x3;
+    /// <summary>AV_IAMF_LAYER_FLAG_RECON_GAIN = 0x1 &lt;&lt; 0x0</summary>
+    public const int AV_IAMF_LAYER_FLAG_RECON_GAIN = 0x1 << 0x0;
     /// <summary>AV_INPUT_BUFFER_PADDING_SIZE = 64</summary>
     public const int AV_INPUT_BUFFER_PADDING_SIZE = 0x40;
     // public static AV_IS_INPUT_DEVICE = (category)((category)(==41) || (category)(==43) || (category)(==45));
@@ -709,6 +718,7 @@ public static unsafe partial class ffmpeg
     /// <summary>AV_OPT_SERIALIZE_SKIP_DEFAULTS = 0x00000001</summary>
     public const int AV_OPT_SERIALIZE_SKIP_DEFAULTS = 0x1;
     // public static av_parity = av_parity_c;
+    // public static av_parse_ratio_quiet = rate;
     /// <summary>AV_PARSER_PTS_NB = 0x4</summary>
     public const int AV_PARSER_PTS_NB = 0x4;
     /// <summary>AV_PIX_FMT_0BGR32 = AV_PIX_FMT_NE(0BGR, RGB0)</summary>
@@ -1220,6 +1230,7 @@ public static unsafe partial class ffmpeg
     public const int AV_TIMECODE_STR_SIZE = 0x17;
     // public static AV_TOSTRING = (s) #s;
     // public static av_uninit = (x) x=x;
+    // public static av_unreachable = (msg)                                             do {                                                                    av_log(NULL, AV_LOG_PANIC,                                          "Reached supposedly unreachable code at %s:%d: %s\n",        __FILE__, __LINE__, msg);                                    abort();                                                            } while (0);
     // public static av_unused = __attribute__((unused));
     // public static av_used = __attribute__((used));
     // public static AV_VERSION = a;

--- a/FFmpeg.AutoGen.Abstractions/generated/vectors.g.cs
+++ b/FFmpeg.AutoGen.Abstractions/generated/vectors.g.cs
@@ -37,6 +37,10 @@ public static unsafe partial class vectors
     public static av_append_packet_delegate av_append_packet;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_assert0_fpu_delegate();
+    public static av_assert0_fpu_delegate av_assert0_fpu;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVAudioFifo* av_audio_fifo_alloc_delegate(AVSampleFormat @sample_fmt, int @channels, int @nb_samples);
     public static av_audio_fifo_alloc_delegate av_audio_fifo_alloc;
     
@@ -790,6 +794,133 @@ public static unsafe partial class vectors
     public static av_dynarray2_add_delegate av_dynarray2_add;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_encryption_info_add_side_data_delegate(AVEncryptionInfo* @info, ulong* @side_data_size);
+    public static av_encryption_info_add_side_data_delegate av_encryption_info_add_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_alloc_delegate(uint @subsample_count, uint @key_id_size, uint @iv_size);
+    public static av_encryption_info_alloc_delegate av_encryption_info_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_clone_delegate(AVEncryptionInfo* @info);
+    public static av_encryption_info_clone_delegate av_encryption_info_clone;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_encryption_info_free_delegate(AVEncryptionInfo* @info);
+    public static av_encryption_info_free_delegate av_encryption_info_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_get_side_data_delegate(byte* @side_data, ulong @side_data_size);
+    public static av_encryption_info_get_side_data_delegate av_encryption_info_get_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_encryption_init_info_add_side_data_delegate(AVEncryptionInitInfo* @info, ulong* @side_data_size);
+    public static av_encryption_init_info_add_side_data_delegate av_encryption_init_info_add_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInitInfo* av_encryption_init_info_alloc_delegate(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size);
+    public static av_encryption_init_info_alloc_delegate av_encryption_init_info_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_encryption_init_info_free_delegate(AVEncryptionInitInfo* @info);
+    public static av_encryption_init_info_free_delegate av_encryption_init_info_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInitInfo* av_encryption_init_info_get_side_data_delegate(byte* @side_data, ulong @side_data_size);
+    public static av_encryption_init_info_get_side_data_delegate av_encryption_init_info_get_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVExifMetadata* av_exif_clone_ifd_delegate(AVExifMetadata* @ifd);
+    public static av_exif_clone_ifd_delegate av_exif_clone_ifd;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_exif_free_delegate(AVExifMetadata* @ifd);
+    public static av_exif_free_delegate av_exif_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_get_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value);
+    public static av_exif_get_entry_delegate av_exif_get_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_get_tag_id_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @name);
+    public static av_exif_get_tag_id_delegate av_exif_get_tag_id;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public delegate string av_exif_get_tag_name_delegate(ushort @id);
+    public static av_exif_get_tag_name_delegate av_exif_get_tag_name;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_ifd_to_dict_delegate(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata);
+    public static av_exif_ifd_to_dict_delegate av_exif_ifd_to_dict;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_matrix_to_orientation_delegate(int* @matrix);
+    public static av_exif_matrix_to_orientation_delegate av_exif_matrix_to_orientation;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_orientation_to_matrix_delegate(int* @matrix, int @orientation);
+    public static av_exif_orientation_to_matrix_delegate av_exif_orientation_to_matrix;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_parse_buffer_delegate(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode);
+    public static av_exif_parse_buffer_delegate av_exif_parse_buffer;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_remove_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags);
+    public static av_exif_remove_entry_delegate av_exif_remove_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_set_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value);
+    public static av_exif_set_entry_delegate av_exif_set_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_write_delegate(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode);
+    public static av_exif_write_delegate av_exif_write;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_count_func_delegate(AVExpr* @e, uint* @counter, int @size, int @arg);
+    public static av_expr_count_func_delegate av_expr_count_func;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_count_vars_delegate(AVExpr* @e, uint* @counter, int @size);
+    public static av_expr_count_vars_delegate av_expr_count_vars;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate double av_expr_eval_delegate(AVExpr* @e, double* @const_values, void* @opaque);
+    public static av_expr_eval_delegate av_expr_eval;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_expr_free_delegate(AVExpr* @e);
+    public static av_expr_free_delegate av_expr_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_parse_delegate(AVExpr** @expr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx);
+    public static av_expr_parse_delegate av_expr_parse;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_parse_and_eval_delegate(double* @res,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx);
+    public static av_expr_parse_and_eval_delegate av_expr_parse_and_eval;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_fast_malloc_delegate(void* @ptr, uint* @size, ulong @min_size);
     public static av_fast_malloc_delegate av_fast_malloc;
     
@@ -848,6 +979,22 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_find_default_stream_index_delegate(AVFormatContext* @s);
     public static av_find_default_stream_index_delegate av_find_default_stream_index;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_find_info_tag_delegate(byte* @arg, int @arg_size,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @tag1,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @info);
+    public static av_find_info_tag_delegate av_find_info_tag;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVInputFormat* av_find_input_format_delegate(    
@@ -1051,6 +1198,11 @@ public static unsafe partial class vectors
     #endif
     string @path, int @number, int @flags);
     public static av_get_frame_filename2_delegate av_get_frame_filename2;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public delegate string av_get_known_color_name_delegate(int @color_idx, byte** @rgb);
+    public static av_get_known_color_name_delegate av_get_known_color_name;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
@@ -1296,6 +1448,54 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_hwframe_transfer_get_formats_delegate(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags);
     public static av_hwframe_transfer_get_formats_delegate av_hwframe_transfer_get_formats;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFLayer* av_iamf_audio_element_add_layer_delegate(AVIAMFAudioElement* @audio_element);
+    public static av_iamf_audio_element_add_layer_delegate av_iamf_audio_element_add_layer;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFAudioElement* av_iamf_audio_element_alloc_delegate();
+    public static av_iamf_audio_element_alloc_delegate av_iamf_audio_element_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_iamf_audio_element_free_delegate(AVIAMFAudioElement** @audio_element);
+    public static av_iamf_audio_element_free_delegate av_iamf_audio_element_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_audio_element_get_class_delegate();
+    public static av_iamf_audio_element_get_class_delegate av_iamf_audio_element_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmix* av_iamf_mix_presentation_add_submix_delegate(AVIAMFMixPresentation* @mix_presentation);
+    public static av_iamf_mix_presentation_add_submix_delegate av_iamf_mix_presentation_add_submix;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFMixPresentation* av_iamf_mix_presentation_alloc_delegate();
+    public static av_iamf_mix_presentation_alloc_delegate av_iamf_mix_presentation_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_iamf_mix_presentation_free_delegate(AVIAMFMixPresentation** @mix_presentation);
+    public static av_iamf_mix_presentation_free_delegate av_iamf_mix_presentation_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_mix_presentation_get_class_delegate();
+    public static av_iamf_mix_presentation_get_class_delegate av_iamf_mix_presentation_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFParamDefinition* av_iamf_param_definition_alloc_delegate(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size);
+    public static av_iamf_param_definition_alloc_delegate av_iamf_param_definition_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_param_definition_get_class_delegate();
+    public static av_iamf_param_definition_get_class_delegate av_iamf_param_definition_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmixElement* av_iamf_submix_add_element_delegate(AVIAMFSubmix* @submix);
+    public static av_iamf_submix_add_element_delegate av_iamf_submix_add_element;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmixLayout* av_iamf_submix_add_layout_delegate(AVIAMFSubmix* @submix);
+    public static av_iamf_submix_add_layout_delegate av_iamf_submix_add_layout;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_image_alloc_delegate(ref byte_ptr4 @pointers, ref int4 @linesizes, int @w, int @h, AVPixelFormat @pix_fmt, int @align);
@@ -2145,6 +2345,16 @@ public static unsafe partial class vectors
     public static av_packet_unref_delegate av_packet_unref;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_color_delegate(byte* @rgba_color,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @color_string, int @slen, void* @log_ctx);
+    public static av_parse_color_delegate av_parse_color;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_parse_cpu_caps_delegate(uint* @flags,     
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -2153,6 +2363,46 @@ public static unsafe partial class vectors
     #endif
     string @s);
     public static av_parse_cpu_caps_delegate av_parse_cpu_caps;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_ratio_delegate(AVRational* @q,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str, int @max, int @log_offset, void* @log_ctx);
+    public static av_parse_ratio_delegate av_parse_ratio;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_time_delegate(long* @timeval,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @timestr, int @duration);
+    public static av_parse_time_delegate av_parse_time;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_video_rate_delegate(AVRational* @rate,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    public static av_parse_video_rate_delegate av_parse_video_rate;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_video_size_delegate(int* @width_ptr, int* @height_ptr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    public static av_parse_video_size_delegate av_parse_video_size;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_parser_close_delegate(AVCodecParserContext* @s);
@@ -2381,6 +2631,22 @@ public static unsafe partial class vectors
     public static av_size_mult_delegate av_size_mult;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_small_strptime_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @p,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @fmt, tm* @dt);
+    public static av_small_strptime_delegate av_small_strptime;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate byte* av_strdup_delegate(    
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -2415,6 +2681,16 @@ public static unsafe partial class vectors
     #endif
     string @s, ulong @len);
     public static av_strndup_delegate av_strndup;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate double av_strtod_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @numstr, byte** @tail);
+    public static av_strtod_delegate av_strtod;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVRational av_sub_q_delegate(AVRational @b, AVRational @c);
@@ -2471,6 +2747,10 @@ public static unsafe partial class vectors
     public static av_timecode_make_string_delegate av_timecode_make_string;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate long av_timegm_delegate(tm* @tm);
+    public static av_timegm_delegate av_timegm;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_tree_destroy_delegate(AVTreeNode* @t);
     public static av_tree_destroy_delegate av_tree_destroy;
     
@@ -2489,6 +2769,14 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVTreeNode* av_tree_node_alloc_delegate();
     public static av_tree_node_alloc_delegate av_tree_node_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_tx_init_delegate(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags);
+    public static av_tx_init_delegate av_tx_init;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_tx_uninit_delegate(AVTXContext** @ctx);
+    public static av_tx_uninit_delegate av_tx_uninit;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_url_split_delegate(byte* @proto, int @proto_size, byte* @authorization, int @authorization_size, byte* @hostname, int @hostname_size, int* @port_ptr, byte* @path, int @path_size,     

--- a/FFmpeg.AutoGen.Bindings.DynamicallyLinked/FFmpeg.AutoGen.Bindings.DynamicallyLinked.csproj.lscache
+++ b/FFmpeg.AutoGen.Bindings.DynamicallyLinked/FFmpeg.AutoGen.Bindings.DynamicallyLinked.csproj.lscache
@@ -1,0 +1,359 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.0
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.DynamicallyLinked
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLinked.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=7.3
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.DynamicallyLinked
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.DynamicallyLinked.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLinked.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLinked.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+generated/DynamicallyLinkedBindings.g.cs
+obj/Debug/netstandard2.0/
+ .NETStandard,Version=v2.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.DynamicallyLinked.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.0/FFmpeg.AutoGen.Abstractions.dll
+<NUGET>/netstandard.library/2.0.3/build/netstandard2.0/ref/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.ObjectModel.dll
+ System.Reflection.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.DynamicallyLinked.GeneratedMSBuildEditorConfig.editorconfig
+
+---
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.1
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.DynamicallyLinked
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLinked.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.DynamicallyLinked
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.DynamicallyLinked.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLinked.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLinked.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+generated/DynamicallyLinkedBindings.g.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.DynamicallyLinked.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.dll
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.DynamicallyLinked.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.Bindings.DynamicallyLinked/generated/DynamicallyLinkedBindings.g.cs
+++ b/FFmpeg.AutoGen.Bindings.DynamicallyLinked/generated/DynamicallyLinkedBindings.g.cs
@@ -51,6 +51,11 @@ public static unsafe partial class DynamicallyLinkedBindings
     [DllImport("avformat-63", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_append_packet(AVIOContext* @s, AVPacket* @pkt, int @size);
     
+    /// <summary>Assert that floating point operations can be executed.</summary>
+    [Obsolete("without replacement")]
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_assert0_fpu();
+    
     /// <summary>Allocate an AVAudioFifo.</summary>
     /// <param name="sample_fmt">sample format</param>
     /// <param name="channels">number of channels</param>
@@ -1083,6 +1088,178 @@ public static unsafe partial class DynamicallyLinkedBindings
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern void* av_dynarray2_add(void** @tab_ptr, int* @nb_ptr, ulong @elem_size, byte* @elem_data);
     
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_encryption_info_add_side_data(AVEncryptionInfo* @info, ulong* @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure and sub-pointers to hold the given number of subsamples. This will allocate pointers for the key ID, IV, and subsample entries, set the size members, and zero-initialize the rest.</summary>
+    /// <param name="subsample_count">The number of subsamples.</param>
+    /// <param name="key_id_size">The number of bytes in the key ID, should be 16.</param>
+    /// <param name="iv_size">The number of bytes in the IV, should be 16.</param>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_alloc(uint @subsample_count, uint @key_id_size, uint @iv_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure with a copy of the given data.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_clone(AVEncryptionInfo* @info);
+    
+    /// <summary>Frees the given encryption info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_encryption_info_free(AVEncryptionInfo* @info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInfo that is contained in the given side data. The resulting object should be passed to av_encryption_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_get_side_data(byte* @side_data, ulong @side_data_size);
+    
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption init info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_encryption_init_info_add_side_data(AVEncryptionInitInfo* @info, ulong* @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInitInfo structure and sub-pointers to hold the given sizes. This will allocate pointers and set all the fields.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInitInfo* av_encryption_init_info_alloc(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size);
+    
+    /// <summary>Frees the given encryption init info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_encryption_init_info_free(AVEncryptionInitInfo* @info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInitInfo that is contained in the given side data. The resulting object should be passed to av_encryption_init_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInitInfo* av_encryption_init_info_get_side_data(byte* @side_data, ulong @side_data_size);
+    
+    /// <summary>Allocates a duplicate of the provided EXIF metadata struct. The caller owns the duplicate and must free it with av_exif_free. Returns NULL if the duplication process failed.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVExifMetadata* av_exif_clone_ifd(AVExifMetadata* @ifd);
+    
+    /// <summary>Frees all resources associated with the given EXIF metadata struct. Does not free the pointer passed itself, in case it is stack-allocated. The pointer passed to this function must be freed by the caller, if it is heap-allocated. Passing NULL is permitted.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_exif_free(AVExifMetadata* @ifd);
+    
+    /// <summary>Get an entry with the tagged ID from the EXIF metadata struct. A pointer to the entry will be written into *value.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_get_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value);
+    
+    /// <summary>Retrieves the tag ID associated with the provided tag string name. If the tag name is unknown, a negative number is returned. Otherwise it always fits inside a uint16_t integer.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_get_tag_id(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @name);
+    
+    /// <summary>Retrieves the tag name associated with the provided tag ID. If the tag ID is unknown, NULL is returned.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public static extern string av_exif_get_tag_name(ushort @id);
+    
+    /// <summary>Recursively reads all tags from the IFD and stores them in the provided metadata dictionary.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_ifd_to_dict(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata);
+    
+    /// <summary>Convert a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX into an orientation constant used by EXIF&apos;s orientation tag.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_matrix_to_orientation(int* @matrix);
+    
+    /// <summary>Convert an orientation constant used by EXIF&apos;s orientation tag into a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_orientation_to_matrix(int* @matrix, int @orientation);
+    
+    /// <summary>Decodes the EXIF data provided in the buffer and writes it into the struct *ifd. If this function succeeds, the IFD is owned by the caller and must be cleared after use by calling av_exif_free(); If this function fails and returns a negative value, it will call av_exif_free(ifd) before returning.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_parse_buffer(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode);
+    
+    /// <summary>Remove an entry from the provided EXIF metadata struct.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_remove_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags);
+    
+    /// <summary>Add an entry to the provided EXIF metadata struct. If one already exists with the provided ID, it will set the existing one to have the other information provided. Otherwise, it will allocate a new entry.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_set_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value);
+    
+    /// <summary>Allocates a buffer using av_malloc of an appropriate size and writes the EXIF data represented by ifd into that buffer.</summary>
+    [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_write(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode);
+    
+    /// <summary>Track the presence of user provided functions and their number of occurrences in a parsed expression.</summary>
+    /// <param name="e">the AVExpr to track user provided functions in</param>
+    /// <param name="counter">a zero-initialized array where the count of each function will be stored if you passed 5 functions with 2 arguments to av_expr_parse() then for arg=2 this will use up to 5 entries.</param>
+    /// <param name="size">size of array</param>
+    /// <param name="arg">number of arguments the counted functions have</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_count_func(AVExpr* @e, uint* @counter, int @size, int @arg);
+    
+    /// <summary>Track the presence of variables and their number of occurrences in a parsed expression</summary>
+    /// <param name="e">the AVExpr to track variables in</param>
+    /// <param name="counter">a zero-initialized array where the count of each variable will be stored</param>
+    /// <param name="size">size of array</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_count_vars(AVExpr* @e, uint* @counter, int @size);
+    
+    /// <summary>Evaluate a previously parsed expression.</summary>
+    /// <param name="e">the AVExpr to evaluate</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from av_expr_parse() const_names</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <returns>the value of the expression</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern double av_expr_eval(AVExpr* @e, double* @const_values, void* @opaque);
+    
+    /// <summary>Free a parsed expression previously created with av_expr_parse().</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_expr_free(AVExpr* @e);
+    
+    /// <summary>Parse an expression.</summary>
+    /// <param name="expr">a pointer where is put an AVExpr containing the parsed value in case of successful parsing, or NULL otherwise. The pointed to AVExpr must be freed with av_expr_free() by the user when it is not needed anymore.</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_parse(AVExpr** @expr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx);
+    
+    /// <summary>Parse and evaluate an expression. Note, this is significantly slower than av_expr_eval().</summary>
+    /// <param name="res">a pointer to a double where is put the result value of the expression, or NAN in case of error</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from const_names</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_parse_and_eval(double* @res,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx);
+    
     /// <summary>Allocate a buffer, reusing the given one if large enough.</summary>
     /// <param name="ptr">Pointer to pointer to an already allocated buffer. `*ptr` will be overwritten with pointer to new buffer on success or `NULL` on failure</param>
     /// <param name="size">Pointer to the size of buffer `*ptr`. `*size` is updated to the new allocated size, in particular 0 in case of failure.</param>
@@ -1173,6 +1350,22 @@ public static unsafe partial class DynamicallyLinkedBindings
     
     [DllImport("avformat-63", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_find_default_stream_index(AVFormatContext* @s);
+    
+    /// <summary>Attempt to find a specific tag in a URL.</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_find_info_tag(byte* @arg, int @arg_size,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @tag1,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @info);
     
     /// <summary>Find AVInputFormat based on the short name of the input format.</summary>
     [DllImport("avformat-63", CallingConvention = CallingConvention.Cdecl)]
@@ -1456,6 +1649,14 @@ public static unsafe partial class DynamicallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @path, int @number, int @flags);
+    
+    /// <summary>Get the name of a color from the internal table of hard-coded named colors.</summary>
+    /// <param name="color_idx">index of the requested color, starting from 0</param>
+    /// <param name="rgb">if not NULL, will point to a 3-elements array with the color value in RGB</param>
+    /// <returns>the color name string or NULL if color_idx is not in the array</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public static extern string av_get_known_color_name(int @color_idx, byte** @rgb);
     
     /// <summary>Return a string describing the media_type enum, NULL if media_type is unknown.</summary>
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
@@ -1809,6 +2010,57 @@ public static unsafe partial class DynamicallyLinkedBindings
     /// <returns>0 on success, a negative AVERROR code on failure.</returns>
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_hwframe_transfer_get_formats(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags);
+    
+    /// <summary>Allocate a layer and add it to a given AVIAMFAudioElement. It is freed by av_iamf_audio_element_free() alongside the rest of the parent AVIAMFAudioElement.</summary>
+    /// <returns>a pointer to the allocated layer.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFLayer* av_iamf_audio_element_add_layer(AVIAMFAudioElement* @audio_element);
+    
+    /// <summary>Allocates a AVIAMFAudioElement, and initializes its fields with default values. No layers are allocated. Must be freed with av_iamf_audio_element_free().</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFAudioElement* av_iamf_audio_element_alloc();
+    
+    /// <summary>Free an AVIAMFAudioElement and all its contents.</summary>
+    /// <param name="audio_element">pointer to pointer to an allocated AVIAMFAudioElement. upon return, *audio_element will be set to NULL.</param>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_iamf_audio_element_free(AVIAMFAudioElement** @audio_element);
+    
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_audio_element_get_class();
+    
+    /// <summary>Allocate a submix and add it to a given AVIAMFMixPresentation. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFMixPresentation.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmix* av_iamf_mix_presentation_add_submix(AVIAMFMixPresentation* @mix_presentation);
+    
+    /// <summary>Allocates a AVIAMFMixPresentation, and initializes its fields with default values. No submixes are allocated. Must be freed with av_iamf_mix_presentation_free().</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFMixPresentation* av_iamf_mix_presentation_alloc();
+    
+    /// <summary>Free an AVIAMFMixPresentation and all its contents.</summary>
+    /// <param name="mix_presentation">pointer to pointer to an allocated AVIAMFMixPresentation. upon return, *mix_presentation will be set to NULL.</param>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_iamf_mix_presentation_free(AVIAMFMixPresentation** @mix_presentation);
+    
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_mix_presentation_get_class();
+    
+    /// <summary>Allocates memory for AVIAMFParamDefinition, plus an array of {</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFParamDefinition* av_iamf_param_definition_alloc(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size);
+    
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_param_definition_get_class();
+    
+    /// <summary>Allocate a submix element and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmixElement* av_iamf_submix_add_element(AVIAMFSubmix* @submix);
+    
+    /// <summary>Allocate a submix layout and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmixLayout* av_iamf_submix_add_layout(AVIAMFSubmix* @submix);
     
     /// <summary>Allocate an image with size w and h and pixel format pix_fmt, and fill pointers and linesizes accordingly. The allocated image buffer has to be freed by using av_freep(&amp;pointers[0]).</summary>
     /// <param name="pointers">array to be filled with the pointer for each image plane</param>
@@ -2950,6 +3202,21 @@ public static unsafe partial class DynamicallyLinkedBindings
     [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_packet_unref(AVPacket* @pkt);
     
+    /// <summary>Put the RGBA values that correspond to color_string in rgba_color.</summary>
+    /// <param name="rgba_color">4-elements array of uint8_t values, where the respective red, green, blue and alpha component values are written.</param>
+    /// <param name="color_string">a string specifying a color. It can be the name of a color (case insensitive match) or a [0x|#]RRGGBB[AA] sequence, possibly followed by &quot; &quot; and a string representing the alpha component. The alpha component may be a string composed by &quot;0x&quot; followed by an hexadecimal number or a decimal number between 0.0 and 1.0, which represents the opacity value (0x00/0.0 means completely transparent, 0xff/1.0 completely opaque). If the alpha component is not specified then 0xff is assumed. The string &quot;random&quot; will result in a random color.</param>
+    /// <param name="slen">length of the initial part of color_string containing the color. It can be set to -1 if color_string is a null terminated string containing nothing else than the color.</param>
+    /// <param name="log_ctx">a pointer to an arbitrary struct of which the first field is a pointer to an AVClass struct (used for av_log()). Can be NULL.</param>
+    /// <returns>&gt;= 0 in case of success, a negative value in case of failure (for example if color_string cannot be parsed).</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_color(byte* @rgba_color,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @color_string, int @slen, void* @log_ctx);
+    
     /// <summary>Parse CPU caps from a string and update the given AV_CPU_* flags based on that.</summary>
     /// <returns>negative on error.</returns>
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
@@ -2960,6 +3227,63 @@ public static unsafe partial class DynamicallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @s);
+    
+    /// <summary>Parse str and store the parsed ratio in q.</summary>
+    /// <param name="q">pointer to the AVRational which will contain the ratio</param>
+    /// <param name="str">the string to parse: it has to be a string in the format num:den, a float number or an expression</param>
+    /// <param name="max">the maximum allowed numerator and denominator</param>
+    /// <param name="log_offset">log level offset which is applied to the log level of log_ctx</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_ratio(AVRational* @q,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str, int @max, int @log_offset, void* @log_ctx);
+    
+    /// <summary>Parse timestr and return in *time a corresponding number of microseconds.</summary>
+    /// <param name="timeval">puts here the number of microseconds corresponding to the string in timestr. If the string represents a duration, it is the number of microseconds contained in the time interval.  If the string is a date, is the number of microseconds since 1st of January, 1970 up to the time of the parsed date.  If timestr cannot be successfully parsed, set *time to INT64_MIN.</param>
+    /// <param name="timestr">a string representing a date or a duration. - If a date the syntax is:</param>
+    /// <param name="duration">flag which tells how to interpret timestr, if not zero timestr is interpreted as a duration, otherwise as a date</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_time(long* @timeval,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @timestr, int @duration);
+    
+    /// <summary>Parse str and store the detected values in *rate.</summary>
+    /// <param name="rate">pointer to the AVRational which will contain the detected frame rate</param>
+    /// <param name="str">the string to parse: it has to be a string in the format rate_num / rate_den, a float number or a valid video rate abbreviation</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_video_rate(AVRational* @rate,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    
+    /// <summary>Parse str and put in width_ptr and height_ptr the detected values.</summary>
+    /// <param name="width_ptr">pointer to the variable which will contain the detected width value</param>
+    /// <param name="height_ptr">pointer to the variable which will contain the detected height value</param>
+    /// <param name="str">the string to parse: it has to be a string in the format width x height or a valid video size abbreviation.</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_video_size(int* @width_ptr, int* @height_ptr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
     
     [DllImport("avcodec-63", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_parser_close(AVCodecParserContext* @s);
@@ -3331,6 +3655,23 @@ public static unsafe partial class DynamicallyLinkedBindings
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_size_mult(ulong @a, ulong @b, ulong* @r);
     
+    /// <summary>Simplified version of strptime</summary>
+    /// <returns>a pointer to the first character not processed in this function call. In case the input string contains more characters than required by the format string the return value points right after the last consumed input character. In case the whole input string is consumed the return value points to the null byte at the end of the string. On failure NULL is returned.</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_small_strptime(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @p,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @fmt, tm* @dt);
+    
     /// <summary>Duplicate a string.</summary>
     /// <param name="s">String to be duplicated</param>
     /// <returns>Pointer to a newly-allocated string containing a copy of `s` or `NULL` if the string cannot be allocated</returns>
@@ -3374,6 +3715,18 @@ public static unsafe partial class DynamicallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @s, ulong @len);
+    
+    /// <summary>Parse the string in numstr and return its value as a double. If the string is empty, contains only whitespaces, or does not contain an initial substring that has the expected syntax for a floating-point number, no conversion is performed. In this case, returns a value of zero and the value returned in tail is the value of numstr.</summary>
+    /// <param name="numstr">a string representing a number, may contain one of the International System number postfixes, for example &apos;K&apos;, &apos;M&apos;, &apos;G&apos;. If &apos;i&apos; is appended after the postfix, powers of 2 are used instead of powers of 10. The &apos;B&apos; postfix multiplies the value by 8, and can be appended after another postfix or used alone. This allows using for example &apos;KB&apos;, &apos;MiB&apos;, &apos;G&apos; and &apos;B&apos; as postfix.</param>
+    /// <param name="tail">if non-NULL puts here the pointer to the char next after the last parsed character</param>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern double av_strtod(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @numstr, byte** @tail);
     
     /// <summary>Subtract one rational from another.</summary>
     /// <param name="b">First rational</param>
@@ -3483,6 +3836,10 @@ public static unsafe partial class DynamicallyLinkedBindings
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern byte* av_timecode_make_string(AVTimecode* @tc, byte* @buf, int @framenum);
     
+    /// <summary>Convert the decomposed UTC time in tm to a time_t value.</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern long av_timegm(tm* @tm);
+    
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_tree_destroy(AVTreeNode* @t);
     
@@ -3511,6 +3868,22 @@ public static unsafe partial class DynamicallyLinkedBindings
     /// <summary>Allocate an AVTreeNode.</summary>
     [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
     public static extern AVTreeNode* av_tree_node_alloc();
+    
+    /// <summary>Initialize a transform context with the given configuration (i)MDCTs with an odd length are currently not supported.</summary>
+    /// <param name="ctx">the context to allocate, will be NULL on error</param>
+    /// <param name="tx">pointer to the transform function pointer to set</param>
+    /// <param name="type">type the type of transform</param>
+    /// <param name="inv">whether to do an inverse or a forward transform</param>
+    /// <param name="len">the size of the transform in samples</param>
+    /// <param name="scale">pointer to the value to scale the output if supported by type</param>
+    /// <param name="flags">a bitmask of AVTXFlags or 0</param>
+    /// <returns>0 on success, negative error code on failure</returns>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_tx_init(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags);
+    
+    /// <summary>Frees a context and sets *ctx to NULL, does nothing when *ctx == NULL.</summary>
+    [DllImport("avutil-61", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_tx_uninit(AVTXContext** @ctx);
     
     /// <summary>Split a URL string into components.</summary>
     /// <param name="proto">the buffer for the protocol</param>
@@ -5285,6 +5658,7 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_alpha_mode_from_name = av_alpha_mode_from_name;
         vectors.av_alpha_mode_name = av_alpha_mode_name;
         vectors.av_append_packet = av_append_packet;
+        vectors.av_assert0_fpu = av_assert0_fpu;
         vectors.av_audio_fifo_alloc = av_audio_fifo_alloc;
         vectors.av_audio_fifo_drain = av_audio_fifo_drain;
         vectors.av_audio_fifo_free = av_audio_fifo_free;
@@ -5440,6 +5814,33 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_dynarray_add = av_dynarray_add;
         vectors.av_dynarray_add_nofree = av_dynarray_add_nofree;
         vectors.av_dynarray2_add = av_dynarray2_add;
+        vectors.av_encryption_info_add_side_data = av_encryption_info_add_side_data;
+        vectors.av_encryption_info_alloc = av_encryption_info_alloc;
+        vectors.av_encryption_info_clone = av_encryption_info_clone;
+        vectors.av_encryption_info_free = av_encryption_info_free;
+        vectors.av_encryption_info_get_side_data = av_encryption_info_get_side_data;
+        vectors.av_encryption_init_info_add_side_data = av_encryption_init_info_add_side_data;
+        vectors.av_encryption_init_info_alloc = av_encryption_init_info_alloc;
+        vectors.av_encryption_init_info_free = av_encryption_init_info_free;
+        vectors.av_encryption_init_info_get_side_data = av_encryption_init_info_get_side_data;
+        vectors.av_exif_clone_ifd = av_exif_clone_ifd;
+        vectors.av_exif_free = av_exif_free;
+        vectors.av_exif_get_entry = av_exif_get_entry;
+        vectors.av_exif_get_tag_id = av_exif_get_tag_id;
+        vectors.av_exif_get_tag_name = av_exif_get_tag_name;
+        vectors.av_exif_ifd_to_dict = av_exif_ifd_to_dict;
+        vectors.av_exif_matrix_to_orientation = av_exif_matrix_to_orientation;
+        vectors.av_exif_orientation_to_matrix = av_exif_orientation_to_matrix;
+        vectors.av_exif_parse_buffer = av_exif_parse_buffer;
+        vectors.av_exif_remove_entry = av_exif_remove_entry;
+        vectors.av_exif_set_entry = av_exif_set_entry;
+        vectors.av_exif_write = av_exif_write;
+        vectors.av_expr_count_func = av_expr_count_func;
+        vectors.av_expr_count_vars = av_expr_count_vars;
+        vectors.av_expr_eval = av_expr_eval;
+        vectors.av_expr_free = av_expr_free;
+        vectors.av_expr_parse = av_expr_parse;
+        vectors.av_expr_parse_and_eval = av_expr_parse_and_eval;
         vectors.av_fast_malloc = av_fast_malloc;
         vectors.av_fast_mallocz = av_fast_mallocz;
         vectors.av_fast_padded_malloc = av_fast_padded_malloc;
@@ -5452,6 +5853,7 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_find_best_pix_fmt_of_2 = av_find_best_pix_fmt_of_2;
         vectors.av_find_best_stream = av_find_best_stream;
         vectors.av_find_default_stream_index = av_find_default_stream_index;
+        vectors.av_find_info_tag = av_find_info_tag;
         vectors.av_find_input_format = av_find_input_format;
         vectors.av_find_nearest_q_idx = av_find_nearest_q_idx;
         vectors.av_find_program_from_stream = av_find_program_from_stream;
@@ -5498,6 +5900,7 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_get_exact_bits_per_sample = av_get_exact_bits_per_sample;
         vectors.av_get_frame_filename = av_get_frame_filename;
         vectors.av_get_frame_filename2 = av_get_frame_filename2;
+        vectors.av_get_known_color_name = av_get_known_color_name;
         vectors.av_get_media_type_string = av_get_media_type_string;
         vectors.av_get_output_timestamp = av_get_output_timestamp;
         vectors.av_get_packed_sample_fmt = av_get_packed_sample_fmt;
@@ -5543,6 +5946,18 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_hwframe_map = av_hwframe_map;
         vectors.av_hwframe_transfer_data = av_hwframe_transfer_data;
         vectors.av_hwframe_transfer_get_formats = av_hwframe_transfer_get_formats;
+        vectors.av_iamf_audio_element_add_layer = av_iamf_audio_element_add_layer;
+        vectors.av_iamf_audio_element_alloc = av_iamf_audio_element_alloc;
+        vectors.av_iamf_audio_element_free = av_iamf_audio_element_free;
+        vectors.av_iamf_audio_element_get_class = av_iamf_audio_element_get_class;
+        vectors.av_iamf_mix_presentation_add_submix = av_iamf_mix_presentation_add_submix;
+        vectors.av_iamf_mix_presentation_alloc = av_iamf_mix_presentation_alloc;
+        vectors.av_iamf_mix_presentation_free = av_iamf_mix_presentation_free;
+        vectors.av_iamf_mix_presentation_get_class = av_iamf_mix_presentation_get_class;
+        vectors.av_iamf_param_definition_alloc = av_iamf_param_definition_alloc;
+        vectors.av_iamf_param_definition_get_class = av_iamf_param_definition_get_class;
+        vectors.av_iamf_submix_add_element = av_iamf_submix_add_element;
+        vectors.av_iamf_submix_add_layout = av_iamf_submix_add_layout;
         vectors.av_image_alloc = av_image_alloc;
         vectors.av_image_check_sar = av_image_check_sar;
         vectors.av_image_check_size = av_image_check_size;
@@ -5675,7 +6090,12 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_packet_side_data_to_frame = av_packet_side_data_to_frame;
         vectors.av_packet_unpack_dictionary = av_packet_unpack_dictionary;
         vectors.av_packet_unref = av_packet_unref;
+        vectors.av_parse_color = av_parse_color;
         vectors.av_parse_cpu_caps = av_parse_cpu_caps;
+        vectors.av_parse_ratio = av_parse_ratio;
+        vectors.av_parse_time = av_parse_time;
+        vectors.av_parse_video_rate = av_parse_video_rate;
+        vectors.av_parse_video_size = av_parse_video_size;
         vectors.av_parser_close = av_parser_close;
         vectors.av_parser_init = av_parser_init;
         vectors.av_parser_iterate = av_parser_iterate;
@@ -5725,12 +6145,14 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_set_options_string = av_set_options_string;
         vectors.av_shrink_packet = av_shrink_packet;
         vectors.av_size_mult = av_size_mult;
+        vectors.av_small_strptime = av_small_strptime;
         vectors.av_strdup = av_strdup;
         vectors.av_stream_get_class = av_stream_get_class;
         vectors.av_stream_get_parser = av_stream_get_parser;
         vectors.av_stream_group_get_class = av_stream_group_get_class;
         vectors.av_strerror = av_strerror;
         vectors.av_strndup = av_strndup;
+        vectors.av_strtod = av_strtod;
         vectors.av_sub_q = av_sub_q;
         vectors.av_timecode_adjust_ntsc_framenum2 = av_timecode_adjust_ntsc_framenum2;
         vectors.av_timecode_check_frame_rate = av_timecode_check_frame_rate;
@@ -5743,11 +6165,14 @@ public static unsafe partial class DynamicallyLinkedBindings
         vectors.av_timecode_make_smpte_tc_string = av_timecode_make_smpte_tc_string;
         vectors.av_timecode_make_smpte_tc_string2 = av_timecode_make_smpte_tc_string2;
         vectors.av_timecode_make_string = av_timecode_make_string;
+        vectors.av_timegm = av_timegm;
         vectors.av_tree_destroy = av_tree_destroy;
         vectors.av_tree_enumerate = av_tree_enumerate;
         vectors.av_tree_find = av_tree_find;
         vectors.av_tree_insert = av_tree_insert;
         vectors.av_tree_node_alloc = av_tree_node_alloc;
+        vectors.av_tx_init = av_tx_init;
+        vectors.av_tx_uninit = av_tx_uninit;
         vectors.av_url_split = av_url_split;
         vectors.av_usleep = av_usleep;
         vectors.av_version_info = av_version_info;

--- a/FFmpeg.AutoGen.Bindings.DynamicallyLoaded/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.csproj.lscache
+++ b/FFmpeg.AutoGen.Bindings.DynamicallyLoaded/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.csproj.lscache
@@ -1,0 +1,379 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.0
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.DynamicallyLoaded
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=7.3
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.DynamicallyLoaded
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+DynamicallyLoadedBindings.cs
+FunctionResolverBase.cs
+FunctionResolverFactory.cs
+generated/
+ DynamicallyLoadedBindings.g.cs
+ DynamicallyLoadedBindings.libraries.g.cs
+IFunctionResolver.cs
+Native/
+ LinuxFunctionResolver.cs
+ MacFunctionResolver.cs
+ WindowsFunctionResolver.cs
+obj/Debug/netstandard2.0/
+ .NETStandard,Version=v2.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.DynamicallyLoaded.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.0/FFmpeg.AutoGen.Abstractions.dll
+<NUGET>/netstandard.library/2.0.3/build/netstandard2.0/ref/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.ObjectModel.dll
+ System.Reflection.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.GeneratedMSBuildEditorConfig.editorconfig
+
+---
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.1
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.DynamicallyLoaded
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.DynamicallyLoaded
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.DynamicallyLoaded.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+DynamicallyLoadedBindings.cs
+FunctionResolverBase.cs
+FunctionResolverFactory.cs
+generated/
+ DynamicallyLoadedBindings.g.cs
+ DynamicallyLoadedBindings.libraries.g.cs
+IFunctionResolver.cs
+Native/
+ LinuxFunctionResolver.cs
+ MacFunctionResolver.cs
+ WindowsFunctionResolver.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.DynamicallyLoaded.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.dll
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.Bindings.DynamicallyLoaded/generated/DynamicallyLoadedBindings.g.cs
+++ b/FFmpeg.AutoGen.Bindings.DynamicallyLoaded/generated/DynamicallyLoadedBindings.g.cs
@@ -49,6 +49,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_append_packet(@s, @pkt, @size);
         };
         
+        vectors.av_assert0_fpu = () =>
+        {
+            vectors.av_assert0_fpu = FunctionResolver.GetFunctionDelegate<vectors.av_assert0_fpu_delegate>("avutil", "av_assert0_fpu", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_assert0_fpu();
+        };
+        
         vectors.av_audio_fifo_alloc = (AVSampleFormat @sample_fmt, int @channels, int @nb_samples) =>
         {
             vectors.av_audio_fifo_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_audio_fifo_alloc_delegate>("avutil", "av_audio_fifo_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -979,6 +985,168 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_dynarray2_add(@tab_ptr, @nb_ptr, @elem_size, @elem_data);
         };
         
+        vectors.av_encryption_info_add_side_data = (AVEncryptionInfo* @info, ulong* @side_data_size) =>
+        {
+            vectors.av_encryption_info_add_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_add_side_data_delegate>("avutil", "av_encryption_info_add_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_add_side_data(@info, @side_data_size);
+        };
+        
+        vectors.av_encryption_info_alloc = (uint @subsample_count, uint @key_id_size, uint @iv_size) =>
+        {
+            vectors.av_encryption_info_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_alloc_delegate>("avutil", "av_encryption_info_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_alloc(@subsample_count, @key_id_size, @iv_size);
+        };
+        
+        vectors.av_encryption_info_clone = (AVEncryptionInfo* @info) =>
+        {
+            vectors.av_encryption_info_clone = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_clone_delegate>("avutil", "av_encryption_info_clone", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_clone(@info);
+        };
+        
+        vectors.av_encryption_info_free = (AVEncryptionInfo* @info) =>
+        {
+            vectors.av_encryption_info_free = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_free_delegate>("avutil", "av_encryption_info_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_encryption_info_free(@info);
+        };
+        
+        vectors.av_encryption_info_get_side_data = (byte* @side_data, ulong @side_data_size) =>
+        {
+            vectors.av_encryption_info_get_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_get_side_data_delegate>("avutil", "av_encryption_info_get_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_get_side_data(@side_data, @side_data_size);
+        };
+        
+        vectors.av_encryption_init_info_add_side_data = (AVEncryptionInitInfo* @info, ulong* @side_data_size) =>
+        {
+            vectors.av_encryption_init_info_add_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_add_side_data_delegate>("avutil", "av_encryption_init_info_add_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_add_side_data(@info, @side_data_size);
+        };
+        
+        vectors.av_encryption_init_info_alloc = (uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size) =>
+        {
+            vectors.av_encryption_init_info_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_alloc_delegate>("avutil", "av_encryption_init_info_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_alloc(@system_id_size, @num_key_ids, @key_id_size, @data_size);
+        };
+        
+        vectors.av_encryption_init_info_free = (AVEncryptionInitInfo* @info) =>
+        {
+            vectors.av_encryption_init_info_free = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_free_delegate>("avutil", "av_encryption_init_info_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_encryption_init_info_free(@info);
+        };
+        
+        vectors.av_encryption_init_info_get_side_data = (byte* @side_data, ulong @side_data_size) =>
+        {
+            vectors.av_encryption_init_info_get_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_get_side_data_delegate>("avutil", "av_encryption_init_info_get_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_get_side_data(@side_data, @side_data_size);
+        };
+        
+        vectors.av_exif_clone_ifd = (AVExifMetadata* @ifd) =>
+        {
+            vectors.av_exif_clone_ifd = FunctionResolver.GetFunctionDelegate<vectors.av_exif_clone_ifd_delegate>("avcodec", "av_exif_clone_ifd", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_clone_ifd(@ifd);
+        };
+        
+        vectors.av_exif_free = (AVExifMetadata* @ifd) =>
+        {
+            vectors.av_exif_free = FunctionResolver.GetFunctionDelegate<vectors.av_exif_free_delegate>("avcodec", "av_exif_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_exif_free(@ifd);
+        };
+        
+        vectors.av_exif_get_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value) =>
+        {
+            vectors.av_exif_get_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_entry_delegate>("avcodec", "av_exif_get_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_entry(@logctx, @ifd, @id, @flags, @value);
+        };
+        
+        vectors.av_exif_get_tag_id = (string @name) =>
+        {
+            vectors.av_exif_get_tag_id = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_tag_id_delegate>("avcodec", "av_exif_get_tag_id", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_tag_id(@name);
+        };
+        
+        vectors.av_exif_get_tag_name = (ushort @id) =>
+        {
+            vectors.av_exif_get_tag_name = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_tag_name_delegate>("avcodec", "av_exif_get_tag_name", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_tag_name(@id);
+        };
+        
+        vectors.av_exif_ifd_to_dict = (void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata) =>
+        {
+            vectors.av_exif_ifd_to_dict = FunctionResolver.GetFunctionDelegate<vectors.av_exif_ifd_to_dict_delegate>("avcodec", "av_exif_ifd_to_dict", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_ifd_to_dict(@logctx, @ifd, @metadata);
+        };
+        
+        vectors.av_exif_matrix_to_orientation = (int* @matrix) =>
+        {
+            vectors.av_exif_matrix_to_orientation = FunctionResolver.GetFunctionDelegate<vectors.av_exif_matrix_to_orientation_delegate>("avcodec", "av_exif_matrix_to_orientation", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_matrix_to_orientation(@matrix);
+        };
+        
+        vectors.av_exif_orientation_to_matrix = (int* @matrix, int @orientation) =>
+        {
+            vectors.av_exif_orientation_to_matrix = FunctionResolver.GetFunctionDelegate<vectors.av_exif_orientation_to_matrix_delegate>("avcodec", "av_exif_orientation_to_matrix", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_orientation_to_matrix(@matrix, @orientation);
+        };
+        
+        vectors.av_exif_parse_buffer = (void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode) =>
+        {
+            vectors.av_exif_parse_buffer = FunctionResolver.GetFunctionDelegate<vectors.av_exif_parse_buffer_delegate>("avcodec", "av_exif_parse_buffer", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_parse_buffer(@logctx, @data, @size, @ifd, @header_mode);
+        };
+        
+        vectors.av_exif_remove_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags) =>
+        {
+            vectors.av_exif_remove_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_remove_entry_delegate>("avcodec", "av_exif_remove_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_remove_entry(@logctx, @ifd, @id, @flags);
+        };
+        
+        vectors.av_exif_set_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value) =>
+        {
+            vectors.av_exif_set_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_set_entry_delegate>("avcodec", "av_exif_set_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_set_entry(@logctx, @ifd, @id, @type, @count, @ifd_lead, @ifd_offset, @value);
+        };
+        
+        vectors.av_exif_write = (void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode) =>
+        {
+            vectors.av_exif_write = FunctionResolver.GetFunctionDelegate<vectors.av_exif_write_delegate>("avcodec", "av_exif_write", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_write(@logctx, @ifd, @buffer, @header_mode);
+        };
+        
+        vectors.av_expr_count_func = (AVExpr* @e, uint* @counter, int @size, int @arg) =>
+        {
+            vectors.av_expr_count_func = FunctionResolver.GetFunctionDelegate<vectors.av_expr_count_func_delegate>("avutil", "av_expr_count_func", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_count_func(@e, @counter, @size, @arg);
+        };
+        
+        vectors.av_expr_count_vars = (AVExpr* @e, uint* @counter, int @size) =>
+        {
+            vectors.av_expr_count_vars = FunctionResolver.GetFunctionDelegate<vectors.av_expr_count_vars_delegate>("avutil", "av_expr_count_vars", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_count_vars(@e, @counter, @size);
+        };
+        
+        vectors.av_expr_eval = (AVExpr* @e, double* @const_values, void* @opaque) =>
+        {
+            vectors.av_expr_eval = FunctionResolver.GetFunctionDelegate<vectors.av_expr_eval_delegate>("avutil", "av_expr_eval", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_eval(@e, @const_values, @opaque);
+        };
+        
+        vectors.av_expr_free = (AVExpr* @e) =>
+        {
+            vectors.av_expr_free = FunctionResolver.GetFunctionDelegate<vectors.av_expr_free_delegate>("avutil", "av_expr_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_expr_free(@e);
+        };
+        
+        vectors.av_expr_parse = (AVExpr** @expr, string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_expr_parse = FunctionResolver.GetFunctionDelegate<vectors.av_expr_parse_delegate>("avutil", "av_expr_parse", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_parse(@expr, @s, @const_names, @func1_names, @funcs1, @func2_names, @funcs2, @log_offset, @log_ctx);
+        };
+        
+        vectors.av_expr_parse_and_eval = (double* @res, string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_expr_parse_and_eval = FunctionResolver.GetFunctionDelegate<vectors.av_expr_parse_and_eval_delegate>("avutil", "av_expr_parse_and_eval", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_parse_and_eval(@res, @s, @const_names, @const_values, @func1_names, @funcs1, @func2_names, @funcs2, @opaque, @log_offset, @log_ctx);
+        };
+        
         vectors.av_fast_malloc = (void* @ptr, uint* @size, ulong @min_size) =>
         {
             vectors.av_fast_malloc = FunctionResolver.GetFunctionDelegate<vectors.av_fast_malloc_delegate>("avutil", "av_fast_malloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -1049,6 +1217,12 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_find_default_stream_index = FunctionResolver.GetFunctionDelegate<vectors.av_find_default_stream_index_delegate>("avformat", "av_find_default_stream_index", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_find_default_stream_index(@s);
+        };
+        
+        vectors.av_find_info_tag = (byte* @arg, int @arg_size, string @tag1, string @info) =>
+        {
+            vectors.av_find_info_tag = FunctionResolver.GetFunctionDelegate<vectors.av_find_info_tag_delegate>("avutil", "av_find_info_tag", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_find_info_tag(@arg, @arg_size, @tag1, @info);
         };
         
         vectors.av_find_input_format = (string @short_name) =>
@@ -1327,6 +1501,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_get_frame_filename2(@buf, @buf_size, @path, @number, @flags);
         };
         
+        vectors.av_get_known_color_name = (int @color_idx, byte** @rgb) =>
+        {
+            vectors.av_get_known_color_name = FunctionResolver.GetFunctionDelegate<vectors.av_get_known_color_name_delegate>("avutil", "av_get_known_color_name", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_get_known_color_name(@color_idx, @rgb);
+        };
+        
         vectors.av_get_media_type_string = (AVMediaType @media_type) =>
         {
             vectors.av_get_media_type_string = FunctionResolver.GetFunctionDelegate<vectors.av_get_media_type_string_delegate>("avutil", "av_get_media_type_string", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -1595,6 +1775,78 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_hwframe_transfer_get_formats = FunctionResolver.GetFunctionDelegate<vectors.av_hwframe_transfer_get_formats_delegate>("avutil", "av_hwframe_transfer_get_formats", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_hwframe_transfer_get_formats(@hwframe_ctx, @dir, @formats, @flags);
+        };
+        
+        vectors.av_iamf_audio_element_add_layer = (AVIAMFAudioElement* @audio_element) =>
+        {
+            vectors.av_iamf_audio_element_add_layer = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_add_layer_delegate>("avutil", "av_iamf_audio_element_add_layer", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_add_layer(@audio_element);
+        };
+        
+        vectors.av_iamf_audio_element_alloc = () =>
+        {
+            vectors.av_iamf_audio_element_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_alloc_delegate>("avutil", "av_iamf_audio_element_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_alloc();
+        };
+        
+        vectors.av_iamf_audio_element_free = (AVIAMFAudioElement** @audio_element) =>
+        {
+            vectors.av_iamf_audio_element_free = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_free_delegate>("avutil", "av_iamf_audio_element_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_iamf_audio_element_free(@audio_element);
+        };
+        
+        vectors.av_iamf_audio_element_get_class = () =>
+        {
+            vectors.av_iamf_audio_element_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_get_class_delegate>("avutil", "av_iamf_audio_element_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_get_class();
+        };
+        
+        vectors.av_iamf_mix_presentation_add_submix = (AVIAMFMixPresentation* @mix_presentation) =>
+        {
+            vectors.av_iamf_mix_presentation_add_submix = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_add_submix_delegate>("avutil", "av_iamf_mix_presentation_add_submix", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_add_submix(@mix_presentation);
+        };
+        
+        vectors.av_iamf_mix_presentation_alloc = () =>
+        {
+            vectors.av_iamf_mix_presentation_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_alloc_delegate>("avutil", "av_iamf_mix_presentation_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_alloc();
+        };
+        
+        vectors.av_iamf_mix_presentation_free = (AVIAMFMixPresentation** @mix_presentation) =>
+        {
+            vectors.av_iamf_mix_presentation_free = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_free_delegate>("avutil", "av_iamf_mix_presentation_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_iamf_mix_presentation_free(@mix_presentation);
+        };
+        
+        vectors.av_iamf_mix_presentation_get_class = () =>
+        {
+            vectors.av_iamf_mix_presentation_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_get_class_delegate>("avutil", "av_iamf_mix_presentation_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_get_class();
+        };
+        
+        vectors.av_iamf_param_definition_alloc = (AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size) =>
+        {
+            vectors.av_iamf_param_definition_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_param_definition_alloc_delegate>("avutil", "av_iamf_param_definition_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_param_definition_alloc(@type, @nb_subblocks, @size);
+        };
+        
+        vectors.av_iamf_param_definition_get_class = () =>
+        {
+            vectors.av_iamf_param_definition_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_param_definition_get_class_delegate>("avutil", "av_iamf_param_definition_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_param_definition_get_class();
+        };
+        
+        vectors.av_iamf_submix_add_element = (AVIAMFSubmix* @submix) =>
+        {
+            vectors.av_iamf_submix_add_element = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_submix_add_element_delegate>("avutil", "av_iamf_submix_add_element", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_submix_add_element(@submix);
+        };
+        
+        vectors.av_iamf_submix_add_layout = (AVIAMFSubmix* @submix) =>
+        {
+            vectors.av_iamf_submix_add_layout = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_submix_add_layout_delegate>("avutil", "av_iamf_submix_add_layout", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_submix_add_layout(@submix);
         };
         
         vectors.av_image_alloc = (ref byte_ptr4 @pointers, ref int4 @linesizes, int @w, int @h, AVPixelFormat @pix_fmt, int @align) =>
@@ -2389,10 +2641,40 @@ public static unsafe partial class DynamicallyLoadedBindings
             vectors.av_packet_unref(@pkt);
         };
         
+        vectors.av_parse_color = (byte* @rgba_color, string @color_string, int @slen, void* @log_ctx) =>
+        {
+            vectors.av_parse_color = FunctionResolver.GetFunctionDelegate<vectors.av_parse_color_delegate>("avutil", "av_parse_color", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_color(@rgba_color, @color_string, @slen, @log_ctx);
+        };
+        
         vectors.av_parse_cpu_caps = (uint* @flags, string @s) =>
         {
             vectors.av_parse_cpu_caps = FunctionResolver.GetFunctionDelegate<vectors.av_parse_cpu_caps_delegate>("avutil", "av_parse_cpu_caps", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_parse_cpu_caps(@flags, @s);
+        };
+        
+        vectors.av_parse_ratio = (AVRational* @q, string @str, int @max, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_parse_ratio = FunctionResolver.GetFunctionDelegate<vectors.av_parse_ratio_delegate>("avutil", "av_parse_ratio", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_ratio(@q, @str, @max, @log_offset, @log_ctx);
+        };
+        
+        vectors.av_parse_time = (long* @timeval, string @timestr, int @duration) =>
+        {
+            vectors.av_parse_time = FunctionResolver.GetFunctionDelegate<vectors.av_parse_time_delegate>("avutil", "av_parse_time", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_time(@timeval, @timestr, @duration);
+        };
+        
+        vectors.av_parse_video_rate = (AVRational* @rate, string @str) =>
+        {
+            vectors.av_parse_video_rate = FunctionResolver.GetFunctionDelegate<vectors.av_parse_video_rate_delegate>("avutil", "av_parse_video_rate", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_video_rate(@rate, @str);
+        };
+        
+        vectors.av_parse_video_size = (int* @width_ptr, int* @height_ptr, string @str) =>
+        {
+            vectors.av_parse_video_size = FunctionResolver.GetFunctionDelegate<vectors.av_parse_video_size_delegate>("avutil", "av_parse_video_size", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_video_size(@width_ptr, @height_ptr, @str);
         };
         
         vectors.av_parser_close = (AVCodecParserContext* @s) =>
@@ -2689,6 +2971,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_size_mult(@a, @b, @r);
         };
         
+        vectors.av_small_strptime = (string @p, string @fmt, tm* @dt) =>
+        {
+            vectors.av_small_strptime = FunctionResolver.GetFunctionDelegate<vectors.av_small_strptime_delegate>("avutil", "av_small_strptime", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_small_strptime(@p, @fmt, @dt);
+        };
+        
         vectors.av_strdup = (string @s) =>
         {
             vectors.av_strdup = FunctionResolver.GetFunctionDelegate<vectors.av_strdup_delegate>("avutil", "av_strdup", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -2723,6 +3011,12 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_strndup = FunctionResolver.GetFunctionDelegate<vectors.av_strndup_delegate>("avutil", "av_strndup", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_strndup(@s, @len);
+        };
+        
+        vectors.av_strtod = (string @numstr, byte** @tail) =>
+        {
+            vectors.av_strtod = FunctionResolver.GetFunctionDelegate<vectors.av_strtod_delegate>("avutil", "av_strtod", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_strtod(@numstr, @tail);
         };
         
         vectors.av_sub_q = (AVRational @b, AVRational @c) =>
@@ -2797,6 +3091,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_timecode_make_string(@tc, @buf, @framenum);
         };
         
+        vectors.av_timegm = (tm* @tm) =>
+        {
+            vectors.av_timegm = FunctionResolver.GetFunctionDelegate<vectors.av_timegm_delegate>("avutil", "av_timegm", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_timegm(@tm);
+        };
+        
         vectors.av_tree_destroy = (AVTreeNode* @t) =>
         {
             vectors.av_tree_destroy = FunctionResolver.GetFunctionDelegate<vectors.av_tree_destroy_delegate>("avutil", "av_tree_destroy", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -2825,6 +3125,18 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_tree_node_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_tree_node_alloc_delegate>("avutil", "av_tree_node_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_tree_node_alloc();
+        };
+        
+        vectors.av_tx_init = (AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags) =>
+        {
+            vectors.av_tx_init = FunctionResolver.GetFunctionDelegate<vectors.av_tx_init_delegate>("avutil", "av_tx_init", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_tx_init(@ctx, @tx, @type, @inv, @len, @scale, @flags);
+        };
+        
+        vectors.av_tx_uninit = (AVTXContext** @ctx) =>
+        {
+            vectors.av_tx_uninit = FunctionResolver.GetFunctionDelegate<vectors.av_tx_uninit_delegate>("avutil", "av_tx_uninit", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_tx_uninit(@ctx);
         };
         
         vectors.av_url_split = (byte* @proto, int @proto_size, byte* @authorization, int @authorization_size, byte* @hostname, int @hostname_size, int* @port_ptr, byte* @path, int @path_size, string @url) =>

--- a/FFmpeg.AutoGen.Bindings.StaticallyLinked/FFmpeg.AutoGen.Bindings.StaticallyLinked.csproj.lscache
+++ b/FFmpeg.AutoGen.Bindings.StaticallyLinked/FFmpeg.AutoGen.Bindings.StaticallyLinked.csproj.lscache
@@ -1,0 +1,359 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.0
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.StaticallyLinked
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.StaticallyLinked.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=7.3
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.StaticallyLinked
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.StaticallyLinked.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.StaticallyLinked.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.0\FFmpeg.AutoGen.Bindings.StaticallyLinked.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+generated/StaticallyLinkedBindings.g.cs
+obj/Debug/netstandard2.0/
+ .NETStandard,Version=v2.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.StaticallyLinked.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.0/FFmpeg.AutoGen.Abstractions.dll
+<NUGET>/netstandard.library/2.0.3/build/netstandard2.0/ref/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.ObjectModel.dll
+ System.Reflection.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.0/FFmpeg.AutoGen.Bindings.StaticallyLinked.GeneratedMSBuildEditorConfig.editorconfig
+
+---
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.1
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Bindings.StaticallyLinked
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.StaticallyLinked.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Bindings.StaticallyLinked
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.StaticallyLinked.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,612,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.StaticallyLinked.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.Bindings.StaticallyLinked.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+generated/StaticallyLinkedBindings.g.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Bindings.StaticallyLinked.AssemblyInfo.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.dll
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.StaticallyLinked.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.Bindings.StaticallyLinked/generated/StaticallyLinkedBindings.g.cs
+++ b/FFmpeg.AutoGen.Bindings.StaticallyLinked/generated/StaticallyLinkedBindings.g.cs
@@ -51,6 +51,11 @@ public static unsafe partial class StaticallyLinkedBindings
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_append_packet(AVIOContext* @s, AVPacket* @pkt, int @size);
     
+    /// <summary>Assert that floating point operations can be executed.</summary>
+    [Obsolete("without replacement")]
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_assert0_fpu();
+    
     /// <summary>Allocate an AVAudioFifo.</summary>
     /// <param name="sample_fmt">sample format</param>
     /// <param name="channels">number of channels</param>
@@ -1083,6 +1088,178 @@ public static unsafe partial class StaticallyLinkedBindings
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern void* av_dynarray2_add(void** @tab_ptr, int* @nb_ptr, ulong @elem_size, byte* @elem_data);
     
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_encryption_info_add_side_data(AVEncryptionInfo* @info, ulong* @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure and sub-pointers to hold the given number of subsamples. This will allocate pointers for the key ID, IV, and subsample entries, set the size members, and zero-initialize the rest.</summary>
+    /// <param name="subsample_count">The number of subsamples.</param>
+    /// <param name="key_id_size">The number of bytes in the key ID, should be 16.</param>
+    /// <param name="iv_size">The number of bytes in the IV, should be 16.</param>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_alloc(uint @subsample_count, uint @key_id_size, uint @iv_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure with a copy of the given data.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_clone(AVEncryptionInfo* @info);
+    
+    /// <summary>Frees the given encryption info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_encryption_info_free(AVEncryptionInfo* @info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInfo that is contained in the given side data. The resulting object should be passed to av_encryption_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInfo* av_encryption_info_get_side_data(byte* @side_data, ulong @side_data_size);
+    
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption init info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_encryption_init_info_add_side_data(AVEncryptionInitInfo* @info, ulong* @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInitInfo structure and sub-pointers to hold the given sizes. This will allocate pointers and set all the fields.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInitInfo* av_encryption_init_info_alloc(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size);
+    
+    /// <summary>Frees the given encryption init info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_encryption_init_info_free(AVEncryptionInitInfo* @info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInitInfo that is contained in the given side data. The resulting object should be passed to av_encryption_init_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVEncryptionInitInfo* av_encryption_init_info_get_side_data(byte* @side_data, ulong @side_data_size);
+    
+    /// <summary>Allocates a duplicate of the provided EXIF metadata struct. The caller owns the duplicate and must free it with av_exif_free. Returns NULL if the duplication process failed.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVExifMetadata* av_exif_clone_ifd(AVExifMetadata* @ifd);
+    
+    /// <summary>Frees all resources associated with the given EXIF metadata struct. Does not free the pointer passed itself, in case it is stack-allocated. The pointer passed to this function must be freed by the caller, if it is heap-allocated. Passing NULL is permitted.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_exif_free(AVExifMetadata* @ifd);
+    
+    /// <summary>Get an entry with the tagged ID from the EXIF metadata struct. A pointer to the entry will be written into *value.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_get_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value);
+    
+    /// <summary>Retrieves the tag ID associated with the provided tag string name. If the tag name is unknown, a negative number is returned. Otherwise it always fits inside a uint16_t integer.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_get_tag_id(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @name);
+    
+    /// <summary>Retrieves the tag name associated with the provided tag ID. If the tag ID is unknown, NULL is returned.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public static extern string av_exif_get_tag_name(ushort @id);
+    
+    /// <summary>Recursively reads all tags from the IFD and stores them in the provided metadata dictionary.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_ifd_to_dict(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata);
+    
+    /// <summary>Convert a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX into an orientation constant used by EXIF&apos;s orientation tag.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_matrix_to_orientation(int* @matrix);
+    
+    /// <summary>Convert an orientation constant used by EXIF&apos;s orientation tag into a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_orientation_to_matrix(int* @matrix, int @orientation);
+    
+    /// <summary>Decodes the EXIF data provided in the buffer and writes it into the struct *ifd. If this function succeeds, the IFD is owned by the caller and must be cleared after use by calling av_exif_free(); If this function fails and returns a negative value, it will call av_exif_free(ifd) before returning.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_parse_buffer(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode);
+    
+    /// <summary>Remove an entry from the provided EXIF metadata struct.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_remove_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags);
+    
+    /// <summary>Add an entry to the provided EXIF metadata struct. If one already exists with the provided ID, it will set the existing one to have the other information provided. Otherwise, it will allocate a new entry.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_set_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value);
+    
+    /// <summary>Allocates a buffer using av_malloc of an appropriate size and writes the EXIF data represented by ifd into that buffer.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_exif_write(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode);
+    
+    /// <summary>Track the presence of user provided functions and their number of occurrences in a parsed expression.</summary>
+    /// <param name="e">the AVExpr to track user provided functions in</param>
+    /// <param name="counter">a zero-initialized array where the count of each function will be stored if you passed 5 functions with 2 arguments to av_expr_parse() then for arg=2 this will use up to 5 entries.</param>
+    /// <param name="size">size of array</param>
+    /// <param name="arg">number of arguments the counted functions have</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_count_func(AVExpr* @e, uint* @counter, int @size, int @arg);
+    
+    /// <summary>Track the presence of variables and their number of occurrences in a parsed expression</summary>
+    /// <param name="e">the AVExpr to track variables in</param>
+    /// <param name="counter">a zero-initialized array where the count of each variable will be stored</param>
+    /// <param name="size">size of array</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_count_vars(AVExpr* @e, uint* @counter, int @size);
+    
+    /// <summary>Evaluate a previously parsed expression.</summary>
+    /// <param name="e">the AVExpr to evaluate</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from av_expr_parse() const_names</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <returns>the value of the expression</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern double av_expr_eval(AVExpr* @e, double* @const_values, void* @opaque);
+    
+    /// <summary>Free a parsed expression previously created with av_expr_parse().</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_expr_free(AVExpr* @e);
+    
+    /// <summary>Parse an expression.</summary>
+    /// <param name="expr">a pointer where is put an AVExpr containing the parsed value in case of successful parsing, or NULL otherwise. The pointed to AVExpr must be freed with av_expr_free() by the user when it is not needed anymore.</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_parse(AVExpr** @expr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx);
+    
+    /// <summary>Parse and evaluate an expression. Note, this is significantly slower than av_expr_eval().</summary>
+    /// <param name="res">a pointer to a double where is put the result value of the expression, or NAN in case of error</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from const_names</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_expr_parse_and_eval(double* @res,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx);
+    
     /// <summary>Allocate a buffer, reusing the given one if large enough.</summary>
     /// <param name="ptr">Pointer to pointer to an already allocated buffer. `*ptr` will be overwritten with pointer to new buffer on success or `NULL` on failure</param>
     /// <param name="size">Pointer to the size of buffer `*ptr`. `*size` is updated to the new allocated size, in particular 0 in case of failure.</param>
@@ -1173,6 +1350,22 @@ public static unsafe partial class StaticallyLinkedBindings
     
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_find_default_stream_index(AVFormatContext* @s);
+    
+    /// <summary>Attempt to find a specific tag in a URL.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_find_info_tag(byte* @arg, int @arg_size,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @tag1,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @info);
     
     /// <summary>Find AVInputFormat based on the short name of the input format.</summary>
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
@@ -1456,6 +1649,14 @@ public static unsafe partial class StaticallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @path, int @number, int @flags);
+    
+    /// <summary>Get the name of a color from the internal table of hard-coded named colors.</summary>
+    /// <param name="color_idx">index of the requested color, starting from 0</param>
+    /// <param name="rgb">if not NULL, will point to a 3-elements array with the color value in RGB</param>
+    /// <returns>the color name string or NULL if color_idx is not in the array</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public static extern string av_get_known_color_name(int @color_idx, byte** @rgb);
     
     /// <summary>Return a string describing the media_type enum, NULL if media_type is unknown.</summary>
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
@@ -1809,6 +2010,57 @@ public static unsafe partial class StaticallyLinkedBindings
     /// <returns>0 on success, a negative AVERROR code on failure.</returns>
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_hwframe_transfer_get_formats(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags);
+    
+    /// <summary>Allocate a layer and add it to a given AVIAMFAudioElement. It is freed by av_iamf_audio_element_free() alongside the rest of the parent AVIAMFAudioElement.</summary>
+    /// <returns>a pointer to the allocated layer.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFLayer* av_iamf_audio_element_add_layer(AVIAMFAudioElement* @audio_element);
+    
+    /// <summary>Allocates a AVIAMFAudioElement, and initializes its fields with default values. No layers are allocated. Must be freed with av_iamf_audio_element_free().</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFAudioElement* av_iamf_audio_element_alloc();
+    
+    /// <summary>Free an AVIAMFAudioElement and all its contents.</summary>
+    /// <param name="audio_element">pointer to pointer to an allocated AVIAMFAudioElement. upon return, *audio_element will be set to NULL.</param>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_iamf_audio_element_free(AVIAMFAudioElement** @audio_element);
+    
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_audio_element_get_class();
+    
+    /// <summary>Allocate a submix and add it to a given AVIAMFMixPresentation. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFMixPresentation.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmix* av_iamf_mix_presentation_add_submix(AVIAMFMixPresentation* @mix_presentation);
+    
+    /// <summary>Allocates a AVIAMFMixPresentation, and initializes its fields with default values. No submixes are allocated. Must be freed with av_iamf_mix_presentation_free().</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFMixPresentation* av_iamf_mix_presentation_alloc();
+    
+    /// <summary>Free an AVIAMFMixPresentation and all its contents.</summary>
+    /// <param name="mix_presentation">pointer to pointer to an allocated AVIAMFMixPresentation. upon return, *mix_presentation will be set to NULL.</param>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_iamf_mix_presentation_free(AVIAMFMixPresentation** @mix_presentation);
+    
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_mix_presentation_get_class();
+    
+    /// <summary>Allocates memory for AVIAMFParamDefinition, plus an array of {</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFParamDefinition* av_iamf_param_definition_alloc(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size);
+    
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVClass* av_iamf_param_definition_get_class();
+    
+    /// <summary>Allocate a submix element and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmixElement* av_iamf_submix_add_element(AVIAMFSubmix* @submix);
+    
+    /// <summary>Allocate a submix layout and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern AVIAMFSubmixLayout* av_iamf_submix_add_layout(AVIAMFSubmix* @submix);
     
     /// <summary>Allocate an image with size w and h and pixel format pix_fmt, and fill pointers and linesizes accordingly. The allocated image buffer has to be freed by using av_freep(&amp;pointers[0]).</summary>
     /// <param name="pointers">array to be filled with the pointer for each image plane</param>
@@ -2950,6 +3202,21 @@ public static unsafe partial class StaticallyLinkedBindings
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_packet_unref(AVPacket* @pkt);
     
+    /// <summary>Put the RGBA values that correspond to color_string in rgba_color.</summary>
+    /// <param name="rgba_color">4-elements array of uint8_t values, where the respective red, green, blue and alpha component values are written.</param>
+    /// <param name="color_string">a string specifying a color. It can be the name of a color (case insensitive match) or a [0x|#]RRGGBB[AA] sequence, possibly followed by &quot; &quot; and a string representing the alpha component. The alpha component may be a string composed by &quot;0x&quot; followed by an hexadecimal number or a decimal number between 0.0 and 1.0, which represents the opacity value (0x00/0.0 means completely transparent, 0xff/1.0 completely opaque). If the alpha component is not specified then 0xff is assumed. The string &quot;random&quot; will result in a random color.</param>
+    /// <param name="slen">length of the initial part of color_string containing the color. It can be set to -1 if color_string is a null terminated string containing nothing else than the color.</param>
+    /// <param name="log_ctx">a pointer to an arbitrary struct of which the first field is a pointer to an AVClass struct (used for av_log()). Can be NULL.</param>
+    /// <returns>&gt;= 0 in case of success, a negative value in case of failure (for example if color_string cannot be parsed).</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_color(byte* @rgba_color,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @color_string, int @slen, void* @log_ctx);
+    
     /// <summary>Parse CPU caps from a string and update the given AV_CPU_* flags based on that.</summary>
     /// <returns>negative on error.</returns>
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
@@ -2960,6 +3227,63 @@ public static unsafe partial class StaticallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @s);
+    
+    /// <summary>Parse str and store the parsed ratio in q.</summary>
+    /// <param name="q">pointer to the AVRational which will contain the ratio</param>
+    /// <param name="str">the string to parse: it has to be a string in the format num:den, a float number or an expression</param>
+    /// <param name="max">the maximum allowed numerator and denominator</param>
+    /// <param name="log_offset">log level offset which is applied to the log level of log_ctx</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_ratio(AVRational* @q,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str, int @max, int @log_offset, void* @log_ctx);
+    
+    /// <summary>Parse timestr and return in *time a corresponding number of microseconds.</summary>
+    /// <param name="timeval">puts here the number of microseconds corresponding to the string in timestr. If the string represents a duration, it is the number of microseconds contained in the time interval.  If the string is a date, is the number of microseconds since 1st of January, 1970 up to the time of the parsed date.  If timestr cannot be successfully parsed, set *time to INT64_MIN.</param>
+    /// <param name="timestr">a string representing a date or a duration. - If a date the syntax is:</param>
+    /// <param name="duration">flag which tells how to interpret timestr, if not zero timestr is interpreted as a duration, otherwise as a date</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_time(long* @timeval,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @timestr, int @duration);
+    
+    /// <summary>Parse str and store the detected values in *rate.</summary>
+    /// <param name="rate">pointer to the AVRational which will contain the detected frame rate</param>
+    /// <param name="str">the string to parse: it has to be a string in the format rate_num / rate_den, a float number or a valid video rate abbreviation</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_video_rate(AVRational* @rate,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    
+    /// <summary>Parse str and put in width_ptr and height_ptr the detected values.</summary>
+    /// <param name="width_ptr">pointer to the variable which will contain the detected width value</param>
+    /// <param name="height_ptr">pointer to the variable which will contain the detected height value</param>
+    /// <param name="str">the string to parse: it has to be a string in the format width x height or a valid video size abbreviation.</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_parse_video_size(int* @width_ptr, int* @height_ptr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
     
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_parser_close(AVCodecParserContext* @s);
@@ -3331,6 +3655,23 @@ public static unsafe partial class StaticallyLinkedBindings
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern int av_size_mult(ulong @a, ulong @b, ulong* @r);
     
+    /// <summary>Simplified version of strptime</summary>
+    /// <returns>a pointer to the first character not processed in this function call. In case the input string contains more characters than required by the format string the return value points right after the last consumed input character. In case the whole input string is consumed the return value points to the null byte at the end of the string. On failure NULL is returned.</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte* av_small_strptime(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @p,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @fmt, tm* @dt);
+    
     /// <summary>Duplicate a string.</summary>
     /// <param name="s">String to be duplicated</param>
     /// <returns>Pointer to a newly-allocated string containing a copy of `s` or `NULL` if the string cannot be allocated</returns>
@@ -3374,6 +3715,18 @@ public static unsafe partial class StaticallyLinkedBindings
     [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
     #endif
     string @s, ulong @len);
+    
+    /// <summary>Parse the string in numstr and return its value as a double. If the string is empty, contains only whitespaces, or does not contain an initial substring that has the expected syntax for a floating-point number, no conversion is performed. In this case, returns a value of zero and the value returned in tail is the value of numstr.</summary>
+    /// <param name="numstr">a string representing a number, may contain one of the International System number postfixes, for example &apos;K&apos;, &apos;M&apos;, &apos;G&apos;. If &apos;i&apos; is appended after the postfix, powers of 2 are used instead of powers of 10. The &apos;B&apos; postfix multiplies the value by 8, and can be appended after another postfix or used alone. This allows using for example &apos;KB&apos;, &apos;MiB&apos;, &apos;G&apos; and &apos;B&apos; as postfix.</param>
+    /// <param name="tail">if non-NULL puts here the pointer to the char next after the last parsed character</param>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern double av_strtod(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @numstr, byte** @tail);
     
     /// <summary>Subtract one rational from another.</summary>
     /// <param name="b">First rational</param>
@@ -3483,6 +3836,10 @@ public static unsafe partial class StaticallyLinkedBindings
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern byte* av_timecode_make_string(AVTimecode* @tc, byte* @buf, int @framenum);
     
+    /// <summary>Convert the decomposed UTC time in tm to a time_t value.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern long av_timegm(tm* @tm);
+    
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern void av_tree_destroy(AVTreeNode* @t);
     
@@ -3511,6 +3868,22 @@ public static unsafe partial class StaticallyLinkedBindings
     /// <summary>Allocate an AVTreeNode.</summary>
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     public static extern AVTreeNode* av_tree_node_alloc();
+    
+    /// <summary>Initialize a transform context with the given configuration (i)MDCTs with an odd length are currently not supported.</summary>
+    /// <param name="ctx">the context to allocate, will be NULL on error</param>
+    /// <param name="tx">pointer to the transform function pointer to set</param>
+    /// <param name="type">type the type of transform</param>
+    /// <param name="inv">whether to do an inverse or a forward transform</param>
+    /// <param name="len">the size of the transform in samples</param>
+    /// <param name="scale">pointer to the value to scale the output if supported by type</param>
+    /// <param name="flags">a bitmask of AVTXFlags or 0</param>
+    /// <returns>0 on success, negative error code on failure</returns>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern int av_tx_init(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags);
+    
+    /// <summary>Frees a context and sets *ctx to NULL, does nothing when *ctx == NULL.</summary>
+    [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void av_tx_uninit(AVTXContext** @ctx);
     
     /// <summary>Split a URL string into components.</summary>
     /// <param name="proto">the buffer for the protocol</param>
@@ -5285,6 +5658,7 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_alpha_mode_from_name = av_alpha_mode_from_name;
         vectors.av_alpha_mode_name = av_alpha_mode_name;
         vectors.av_append_packet = av_append_packet;
+        vectors.av_assert0_fpu = av_assert0_fpu;
         vectors.av_audio_fifo_alloc = av_audio_fifo_alloc;
         vectors.av_audio_fifo_drain = av_audio_fifo_drain;
         vectors.av_audio_fifo_free = av_audio_fifo_free;
@@ -5440,6 +5814,33 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_dynarray_add = av_dynarray_add;
         vectors.av_dynarray_add_nofree = av_dynarray_add_nofree;
         vectors.av_dynarray2_add = av_dynarray2_add;
+        vectors.av_encryption_info_add_side_data = av_encryption_info_add_side_data;
+        vectors.av_encryption_info_alloc = av_encryption_info_alloc;
+        vectors.av_encryption_info_clone = av_encryption_info_clone;
+        vectors.av_encryption_info_free = av_encryption_info_free;
+        vectors.av_encryption_info_get_side_data = av_encryption_info_get_side_data;
+        vectors.av_encryption_init_info_add_side_data = av_encryption_init_info_add_side_data;
+        vectors.av_encryption_init_info_alloc = av_encryption_init_info_alloc;
+        vectors.av_encryption_init_info_free = av_encryption_init_info_free;
+        vectors.av_encryption_init_info_get_side_data = av_encryption_init_info_get_side_data;
+        vectors.av_exif_clone_ifd = av_exif_clone_ifd;
+        vectors.av_exif_free = av_exif_free;
+        vectors.av_exif_get_entry = av_exif_get_entry;
+        vectors.av_exif_get_tag_id = av_exif_get_tag_id;
+        vectors.av_exif_get_tag_name = av_exif_get_tag_name;
+        vectors.av_exif_ifd_to_dict = av_exif_ifd_to_dict;
+        vectors.av_exif_matrix_to_orientation = av_exif_matrix_to_orientation;
+        vectors.av_exif_orientation_to_matrix = av_exif_orientation_to_matrix;
+        vectors.av_exif_parse_buffer = av_exif_parse_buffer;
+        vectors.av_exif_remove_entry = av_exif_remove_entry;
+        vectors.av_exif_set_entry = av_exif_set_entry;
+        vectors.av_exif_write = av_exif_write;
+        vectors.av_expr_count_func = av_expr_count_func;
+        vectors.av_expr_count_vars = av_expr_count_vars;
+        vectors.av_expr_eval = av_expr_eval;
+        vectors.av_expr_free = av_expr_free;
+        vectors.av_expr_parse = av_expr_parse;
+        vectors.av_expr_parse_and_eval = av_expr_parse_and_eval;
         vectors.av_fast_malloc = av_fast_malloc;
         vectors.av_fast_mallocz = av_fast_mallocz;
         vectors.av_fast_padded_malloc = av_fast_padded_malloc;
@@ -5452,6 +5853,7 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_find_best_pix_fmt_of_2 = av_find_best_pix_fmt_of_2;
         vectors.av_find_best_stream = av_find_best_stream;
         vectors.av_find_default_stream_index = av_find_default_stream_index;
+        vectors.av_find_info_tag = av_find_info_tag;
         vectors.av_find_input_format = av_find_input_format;
         vectors.av_find_nearest_q_idx = av_find_nearest_q_idx;
         vectors.av_find_program_from_stream = av_find_program_from_stream;
@@ -5498,6 +5900,7 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_get_exact_bits_per_sample = av_get_exact_bits_per_sample;
         vectors.av_get_frame_filename = av_get_frame_filename;
         vectors.av_get_frame_filename2 = av_get_frame_filename2;
+        vectors.av_get_known_color_name = av_get_known_color_name;
         vectors.av_get_media_type_string = av_get_media_type_string;
         vectors.av_get_output_timestamp = av_get_output_timestamp;
         vectors.av_get_packed_sample_fmt = av_get_packed_sample_fmt;
@@ -5543,6 +5946,18 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_hwframe_map = av_hwframe_map;
         vectors.av_hwframe_transfer_data = av_hwframe_transfer_data;
         vectors.av_hwframe_transfer_get_formats = av_hwframe_transfer_get_formats;
+        vectors.av_iamf_audio_element_add_layer = av_iamf_audio_element_add_layer;
+        vectors.av_iamf_audio_element_alloc = av_iamf_audio_element_alloc;
+        vectors.av_iamf_audio_element_free = av_iamf_audio_element_free;
+        vectors.av_iamf_audio_element_get_class = av_iamf_audio_element_get_class;
+        vectors.av_iamf_mix_presentation_add_submix = av_iamf_mix_presentation_add_submix;
+        vectors.av_iamf_mix_presentation_alloc = av_iamf_mix_presentation_alloc;
+        vectors.av_iamf_mix_presentation_free = av_iamf_mix_presentation_free;
+        vectors.av_iamf_mix_presentation_get_class = av_iamf_mix_presentation_get_class;
+        vectors.av_iamf_param_definition_alloc = av_iamf_param_definition_alloc;
+        vectors.av_iamf_param_definition_get_class = av_iamf_param_definition_get_class;
+        vectors.av_iamf_submix_add_element = av_iamf_submix_add_element;
+        vectors.av_iamf_submix_add_layout = av_iamf_submix_add_layout;
         vectors.av_image_alloc = av_image_alloc;
         vectors.av_image_check_sar = av_image_check_sar;
         vectors.av_image_check_size = av_image_check_size;
@@ -5675,7 +6090,12 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_packet_side_data_to_frame = av_packet_side_data_to_frame;
         vectors.av_packet_unpack_dictionary = av_packet_unpack_dictionary;
         vectors.av_packet_unref = av_packet_unref;
+        vectors.av_parse_color = av_parse_color;
         vectors.av_parse_cpu_caps = av_parse_cpu_caps;
+        vectors.av_parse_ratio = av_parse_ratio;
+        vectors.av_parse_time = av_parse_time;
+        vectors.av_parse_video_rate = av_parse_video_rate;
+        vectors.av_parse_video_size = av_parse_video_size;
         vectors.av_parser_close = av_parser_close;
         vectors.av_parser_init = av_parser_init;
         vectors.av_parser_iterate = av_parser_iterate;
@@ -5725,12 +6145,14 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_set_options_string = av_set_options_string;
         vectors.av_shrink_packet = av_shrink_packet;
         vectors.av_size_mult = av_size_mult;
+        vectors.av_small_strptime = av_small_strptime;
         vectors.av_strdup = av_strdup;
         vectors.av_stream_get_class = av_stream_get_class;
         vectors.av_stream_get_parser = av_stream_get_parser;
         vectors.av_stream_group_get_class = av_stream_group_get_class;
         vectors.av_strerror = av_strerror;
         vectors.av_strndup = av_strndup;
+        vectors.av_strtod = av_strtod;
         vectors.av_sub_q = av_sub_q;
         vectors.av_timecode_adjust_ntsc_framenum2 = av_timecode_adjust_ntsc_framenum2;
         vectors.av_timecode_check_frame_rate = av_timecode_check_frame_rate;
@@ -5743,11 +6165,14 @@ public static unsafe partial class StaticallyLinkedBindings
         vectors.av_timecode_make_smpte_tc_string = av_timecode_make_smpte_tc_string;
         vectors.av_timecode_make_smpte_tc_string2 = av_timecode_make_smpte_tc_string2;
         vectors.av_timecode_make_string = av_timecode_make_string;
+        vectors.av_timegm = av_timegm;
         vectors.av_tree_destroy = av_tree_destroy;
         vectors.av_tree_enumerate = av_tree_enumerate;
         vectors.av_tree_find = av_tree_find;
         vectors.av_tree_insert = av_tree_insert;
         vectors.av_tree_node_alloc = av_tree_node_alloc;
+        vectors.av_tx_init = av_tx_init;
+        vectors.av_tx_uninit = av_tx_uninit;
         vectors.av_url_split = av_url_split;
         vectors.av_usleep = av_usleep;
         vectors.av_version_info = av_version_info;

--- a/FFmpeg.AutoGen.ClangMacroParser.Test/FFmpeg.AutoGen.ClangMacroParser.Test.csproj.lscache
+++ b/FFmpeg.AutoGen.ClangMacroParser.Test/FFmpeg.AutoGen.ClangMacroParser.Test.csproj.lscache
@@ -1,0 +1,263 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.ClangMacroParser.Test
+CommandLineArgsForDesignTimeEvaluation=-langversion:preview -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=13.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.ClangMacroParser.Test
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net9.0/FFmpeg.AutoGen.ClangMacroParser.Test.dll
+TargetRefPath=<PATH>obj/Debug/net9.0/ref/FFmpeg.AutoGen.ClangMacroParser.Test.dll
+TemporaryDependencyNodeTargetIdentifier=net9.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:1701,1702,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:9
+/define:TRACE;DEBUG;NET;NET9_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net9.0\FFmpeg.AutoGen.ClangMacroParser.Test.dll
+/refout:obj\Debug\net9.0\refint\FFmpeg.AutoGen.ClangMacroParser.Test.dll
+/target:exe
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:preview
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.8.0/build/netcoreapp3.1/Microsoft.NET.Test.Sdk.Program.cs
+obj/Debug/net9.0/
+ .NETCoreApp,Version=v9.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.ClangMacroParser.Test.AssemblyInfo.cs
+ FFmpeg.AutoGen.ClangMacroParser.Test.GlobalUsings.g.cs
+ParserTest.cs
+TokenizerTest.cs
+Usings.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.ClangMacroParser/bin/Debug/netstandard2.1/FFmpeg.AutoGen.ClangMacroParser.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/ref/net9.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ microsoft.codecoverage/17.8.0/lib/netcoreapp3.1/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.testplatform.testhost/17.8.0/lib/netcoreapp3.1/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ mstest.testframework/3.1.1/
+  build/net6.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll
+  lib/net6.0/Microsoft.VisualStudio.TestPlatform.TestFramework.dll
+ newtonsoft.json/13.0.1/lib/netstandard2.0/Newtonsoft.Json.dll
+ nuget.frameworks/6.5.0/lib/netstandard2.0/NuGet.Frameworks.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+
+[analyzerConfigFiles]
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_9_default.globalconfig
+obj/Debug/net9.0/FFmpeg.AutoGen.ClangMacroParser.Test.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.ClangMacroParser/FFmpeg.AutoGen.ClangMacroParser.csproj.lscache
+++ b/FFmpeg.AutoGen.ClangMacroParser/FFmpeg.AutoGen.ClangMacroParser.csproj.lscache
@@ -1,0 +1,200 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.ClangMacroParser
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.ClangMacroParser
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.ClangMacroParser.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:1701,1702,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.ClangMacroParser.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+/warnaserror+:NU1605
+
+[sourceFiles]
+Expressions/
+ BinaryExpression.cs
+ CallExpression.cs
+ CastExpression.cs
+ ConstantExpression.cs
+ IExpression.cs
+ OperationType.cs
+ OperationTypeExtensions.cs
+ UnaryExpression.cs
+ VariableExpression.cs
+NumberParser.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.ClangMacroParser.AssemblyInfo.cs
+Parser.cs
+Tokenization/
+ Token.cs
+ TokenExtensions.cs
+ Tokenizer.cs
+ TokenType.cs
+
+[metadataReferences]
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.ClangMacroParser.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj.lscache
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/FFmpeg.AutoGen.CppSharpUnsafeGenerator.csproj.lscache
@@ -1,0 +1,299 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.CppSharpUnsafeGenerator
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=13.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.CppSharpUnsafeGenerator
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net9.0/FFmpeg.AutoGen.CppSharpUnsafeGenerator.dll
+TargetRefPath=<PATH>obj/Debug/net9.0/ref/FFmpeg.AutoGen.CppSharpUnsafeGenerator.dll
+TemporaryDependencyNodeTargetIdentifier=net9.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:8002,1701,1702,8002
+/fullpaths
+/nostdlib+
+/platform:x64
+/errorreport:prompt
+/warn:9
+/define:TRACE;DEBUG;NET;NET9_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net9.0\FFmpeg.AutoGen.CppSharpUnsafeGenerator.dll
+/refout:obj\Debug\net9.0\refint\FFmpeg.AutoGen.CppSharpUnsafeGenerator.dll
+/target:exe
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+CliOptions.cs
+Definitions/
+ DelegateDefinition.cs
+ EnumerationDefinition.cs
+ EnumerationItem.cs
+ ExportFunctionDefinition.cs
+ FixedArrayDefinition.cs
+ FunctionDefinitionBase.cs
+ FunctionParameter.cs
+ ICanGenerateXmlDoc.cs
+ IDefinition.cs
+ InlineFunctionDefinition.cs
+ IObsoletionAware.cs
+ MacroDefinition.cs
+ NamedDefinition.cs
+ Obsoletion.cs
+ StructureDefinition.cs
+ StructureField.cs
+ TypeDefinition.cs
+ExistingInlineFunctionsHelper.cs
+FunctionExport.cs
+FunctionExportHelper.cs
+Generation/
+ DelegatesGenerator.cs
+ DocExtensions.cs
+ EnumsGenerator.cs
+ FixedArraysGenerator.cs
+ FunctionsGenerator.cs
+ GenerationContext.cs
+ GeneratorBase.cs
+ InlineFunctionsGenerator.cs
+ LibrariesGenerator.cs
+ MacrosGenerator.cs
+ ParametersHelper.cs
+ StructuresGenerator.cs
+obj/Debug/net9.0/
+ .NETCoreApp,Version=v9.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.CppSharpUnsafeGenerator.AssemblyInfo.cs
+Parser.cs
+Processing/
+ ASTProcessor.cs
+ EnumerationProcessor.cs
+ FunctionProcessor.cs
+ MacroPostProcessor.cs
+ MacroProcessor.cs
+ ObsoletionHelper.cs
+ ProcessingContext.cs
+ StructureProcessor.cs
+ TypeHelper.cs
+ TypeOrAlias.cs
+Program.cs
+
+[metadataReferences]
+../FFmpeg.AutoGen.ClangMacroParser/bin/Debug/netstandard2.1/FFmpeg.AutoGen.ClangMacroParser.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/ref/net9.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ commandlineparser/2.9.1/lib/netstandard2.0/CommandLine.dll
+ cppsharp/1.0.1/ref/netcoreapp3.1/
+  CppSharp.AST.dll
+  CppSharp.dll
+  CppSharp.Generator.dll
+  CppSharp.Parser.CSharp.dll
+  CppSharp.Parser.dll
+  CppSharp.Runtime.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+
+[analyzerConfigFiles]
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_9_default.globalconfig
+obj/Debug/net9.0/FFmpeg.AutoGen.CppSharpUnsafeGenerator.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/HeaderCoverage.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/HeaderCoverage.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace FFmpeg.AutoGen.CppSharpUnsafeGenerator;
+
+/// <summary>
+///     Reports FFmpeg headers the parser never saw. The list in <see cref="Program" /> names entry
+///     points, not files: clang follows the includes, so a root brings its whole closure along. What
+///     it cannot bring is a leaf nothing includes - most of libavutil is like that, and a new one
+///     arriving with an FFmpeg release is otherwise only noticed when somebody asks for it.
+/// </summary>
+internal static partial class HeaderCoverage
+{
+    // Headers a public FFmpeg header may include without anything being installed.
+    private static readonly HashSet<string> CStandardLibrary = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "assert.h", "errno.h", "float.h", "inttypes.h", "limits.h", "math.h", "stdarg.h", "stdbool.h",
+        "stddef.h", "stdint.h", "stdio.h", "stdlib.h", "string.h", "time.h", "wchar.h"
+    };
+
+    [GeneratedRegex(@"^\s*#\s*include\s+<(?<header>[^>]+)>", RegexOptions.Multiline)]
+    private static partial Regex AngledInclude();
+
+    public static void Report(string includesDir, IEnumerable<string> parsedFilePaths)
+    {
+        var parsed = new HashSet<string>(
+            parsedFilePaths.Where(x => !string.IsNullOrEmpty(x)).Select(Path.GetFullPath),
+            StringComparer.OrdinalIgnoreCase);
+
+        var unparsed = Directory
+            .EnumerateFiles(includesDir, "*.h", SearchOption.AllDirectories)
+            .Select(Path.GetFullPath)
+            .Where(x => !parsed.Contains(x))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        if (unparsed.Length == 0) return;
+
+        var groups = unparsed.ToLookup(x => ExternalIncludes(x).Length > 0);
+        var selfContained = groups[false].ToArray();
+        var needsSdk = groups[true].ToArray();
+
+        Console.WriteLine();
+        Console.WriteLine($"{unparsed.Length} header(s) under {includesDir} were never parsed.");
+
+        if (needsSdk.Length > 0)
+        {
+            Console.WriteLine($"  {needsSdk.Length} need headers this build does not have, so they cannot be added as they are:");
+            foreach (var path in needsSdk)
+                Console.WriteLine($"    {Relative(includesDir, path)} <- {string.Join(", ", ExternalIncludes(path))}");
+        }
+
+        if (selfContained.Length > 0)
+        {
+            Console.WriteLine($"  {selfContained.Length} include nothing beyond FFmpeg and the C standard library, so adding");
+            Console.WriteLine($"  any of them to the list in Program.Parse would bind it:");
+            foreach (var path in selfContained)
+                Console.WriteLine($"    {Relative(includesDir, path)}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private static string[] ExternalIncludes(string path)
+        => AngledInclude()
+            .Matches(File.ReadAllText(path))
+            .Select(x => x.Groups["header"].Value)
+            .Where(x => !CStandardLibrary.Contains(x) && !x.StartsWith("lib", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string Relative(string includesDir, string path)
+        => Path.GetRelativePath(includesDir, path).Replace(Path.DirectorySeparatorChar, '/');
+}

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -53,6 +53,9 @@ internal class Program
         };
         var processor = new ASTProcessor(processingContext);
         astContexts.ForEach(processor.Process);
+
+        HeaderCoverage.Report(options.FFmpegIncludesDir,
+            astContexts.SelectMany(x => x.TranslationUnits).Where(x => !x.IsSystemHeader).Select(x => x.FilePath));
 
         // generate files
         var inlineFunctions = ExistingInlineFunctionsHelper.LoadInlineFunctions(Path.Combine(options.SolutionDir, "FFmpeg.AutoGen/generated/FFmpeg.functions.inline.g.cs"));

--- a/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
+++ b/FFmpeg.AutoGen.CppSharpUnsafeGenerator/Program.cs
@@ -107,6 +107,12 @@ internal class Program
         yield return p.Parse("libavutil/hwcontext_d3d11va.h");
         yield return p.Parse("libavutil/hdr_dynamic_metadata.h");
         yield return p.Parse("libavutil/mastering_display_metadata.h");
+        yield return p.Parse("libavutil/encryption_info.h");
+        yield return p.Parse("libavutil/eval.h");
+        yield return p.Parse("libavutil/hwcontext_drm.h");
+        yield return p.Parse("libavutil/iamf.h");
+        yield return p.Parse("libavutil/parseutils.h");
+        yield return p.Parse("libavutil/tx.h");
 
         // libswresample
         yield return p.Parse("libswresample/swresample.h");
@@ -117,6 +123,7 @@ internal class Program
         // libavcodec
         yield return p.Parse("libavcodec/avcodec.h");
         yield return p.Parse("libavcodec/bsf.h");
+        yield return p.Parse("libavcodec/exif.h");
         yield return p.Parse("libavcodec/dxva2.h");
         yield return p.Parse("libavcodec/d3d11va.h");
 

--- a/FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj.lscache
+++ b/FFmpeg.AutoGen.Example/FFmpeg.AutoGen.Example.csproj.lscache
@@ -1,0 +1,252 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=FFmpeg.AutoGen.Example
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=13.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen.Example
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net9.0/FFmpeg.AutoGen.Example.dll
+TargetRefPath=<PATH>obj/Debug/net9.0/ref/FFmpeg.AutoGen.Example.dll
+TemporaryDependencyNodeTargetIdentifier=net9.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:1416,1701,1702,8002
+/fullpaths
+/nostdlib+
+/platform:x64
+/errorreport:prompt
+/warn:9
+/define:TRACE;DEBUG;NET;NET9_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net9.0\FFmpeg.AutoGen.Example.dll
+/refout:obj\Debug\net9.0\refint\FFmpeg.AutoGen.Example.dll
+/target:exe
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+FFmpegBinariesHelper.cs
+FFmpegHelper.cs
+H264VideoStreamEncoder.cs
+MediaDecoder.cs
+obj/Debug/net9.0/
+ .NETCoreApp,Version=v9.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.Example.AssemblyInfo.cs
+Program.cs
+VideoFrameConverter.cs
+VideoStreamDecoder.cs
+
+[metadataReferences]
+../
+ FFmpeg.AutoGen.Abstractions/bin/Debug/netstandard2.1/FFmpeg.AutoGen.Abstractions.dll
+ FFmpeg.AutoGen.Bindings.DynamicallyLoaded/bin/Debug/netstandard2.1/FFmpeg.AutoGen.Bindings.DynamicallyLoaded.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/ref/net9.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/skiasharp/2.88.6/lib/net6.0/SkiaSharp.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/9.0.14/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+
+[analyzerConfigFiles]
+<DOTNET>/sdk/10.0.201/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_9_default.globalconfig
+obj/Debug/net9.0/FFmpeg.AutoGen.Example.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj.lscache
+++ b/FFmpeg.AutoGen/FFmpeg.AutoGen.csproj.lscache
@@ -1,0 +1,399 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.0
+
+[properties]
+AssemblyName=FFmpeg.AutoGen
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.0\FFmpeg.AutoGen.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=7.3
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.0/FFmpeg.AutoGen.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.0
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.0\FFmpeg.AutoGen.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.0\FFmpeg.AutoGen.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+ConstCharPtrMarshaler.cs
+FFmpeg.cs
+FunctionResolverBase.cs
+FunctionResolverFactory.cs
+generated/
+ Arrays.g.cs
+ Delegates.g.cs
+ DynamicallyLoadedBindings.g.cs
+ Enums.g.cs
+ ffmpeg.functions.facade.g.cs
+ ffmpeg.functions.inline.g.cs
+ ffmpeg.libraries.g.cs
+ ffmpeg.macros.g.cs
+ Structs.g.cs
+ vectors.g.cs
+IFixedArray.cs
+IFunctionResolver.cs
+Native/
+ LinuxFunctionResolver.cs
+ MacFunctionResolver.cs
+ WindowsFunctionResolver.cs
+obj/Debug/netstandard2.0/
+ .NETStandard,Version=v2.0.AssemblyAttributes.cs
+ FFmpeg.AutoGen.AssemblyInfo.cs
+UTF8Marshaler.cs
+
+[metadataReferences]
+<NUGET>/netstandard.library/2.0.3/build/netstandard2.0/ref/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.ObjectModel.dll
+ System.Reflection.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.0/FFmpeg.AutoGen.GeneratedMSBuildEditorConfig.editorconfig
+
+---
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[sliceDimensions]
+TargetFramework=netstandard2.1
+
+[properties]
+AssemblyName=FFmpeg.AutoGen
+CommandLineArgsForDesignTimeEvaluation=-langversion:latest -define:TRACE -doc:"bin\Debug\netstandard2.1\FFmpeg.AutoGen.xml"
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=8.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=FFmpeg.AutoGen
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../FFmpeg.AutoGen.sln
+TargetFrameworkIdentifier=.NETStandard
+TargetPath=<PATH>bin/Debug/netstandard2.1/FFmpeg.AutoGen.dll
+TargetRefPath=
+TemporaryDependencyNodeTargetIdentifier=netstandard2.1
+
+[commandLineArguments]
+/noconfig
+/unsafe+
+/checked-
+/nowarn:108,169,618,1573,1591,1701,1702,1705,1701,1702
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/doc:bin\Debug\netstandard2.1\FFmpeg.AutoGen.xml
+/define:TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_1;NETSTANDARD1_0_OR_GREATER;NETSTANDARD1_1_OR_GREATER;NETSTANDARD1_2_OR_GREATER;NETSTANDARD1_3_OR_GREATER;NETSTANDARD1_4_OR_GREATER;NETSTANDARD1_5_OR_GREATER;NETSTANDARD1_6_OR_GREATER;NETSTANDARD2_0_OR_GREATER;NETSTANDARD2_1_OR_GREATER
+/highentropyva+
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\netstandard2.1\FFmpeg.AutoGen.dll
+/target:library
+/warnaserror-
+/utf8output
+/deterministic+
+/langversion:latest
+
+[sourceFiles]
+ConstCharPtrMarshaler.cs
+FFmpeg.cs
+FunctionResolverBase.cs
+FunctionResolverFactory.cs
+generated/
+ Arrays.g.cs
+ Delegates.g.cs
+ DynamicallyLoadedBindings.g.cs
+ Enums.g.cs
+ ffmpeg.functions.facade.g.cs
+ ffmpeg.functions.inline.g.cs
+ ffmpeg.libraries.g.cs
+ ffmpeg.macros.g.cs
+ Structs.g.cs
+ vectors.g.cs
+IFixedArray.cs
+IFunctionResolver.cs
+Native/
+ LinuxFunctionResolver.cs
+ MacFunctionResolver.cs
+ WindowsFunctionResolver.cs
+obj/Debug/netstandard2.1/
+ .NETStandard,Version=v2.1.AssemblyAttributes.cs
+ FFmpeg.AutoGen.AssemblyInfo.cs
+UTF8Marshaler.cs
+
+[metadataReferences]
+<DOTNET>/packs/NETStandard.Library.Ref/2.1.0/ref/netstandard2.1/
+ Microsoft.Win32.Primitives.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Composition.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.Sockets.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Primitives.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.Principal.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+
+[analyzerConfigFiles]
+obj/Debug/netstandard2.1/FFmpeg.AutoGen.GeneratedMSBuildEditorConfig.editorconfig

--- a/FFmpeg.AutoGen/generated/Arrays.g.cs
+++ b/FFmpeg.AutoGen/generated/Arrays.g.cs
@@ -200,6 +200,72 @@ public unsafe struct AVComponentDescriptor_array4 : IFixedArray<AVComponentDescr
     public static implicit operator AVComponentDescriptor[](AVComponentDescriptor_array4 @struct) => @struct.ToArray();
 }
 
+public unsafe struct AVDRMLayerDescriptor_array4 : IFixedArray<AVDRMLayerDescriptor>
+{
+    public static readonly int Size = 4;
+    public int Length => 4;
+    AVDRMLayerDescriptor _0; AVDRMLayerDescriptor _1; AVDRMLayerDescriptor _2; AVDRMLayerDescriptor _3;
+    
+    public AVDRMLayerDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMLayerDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMLayerDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMLayerDescriptor[] ToArray()
+    {
+        fixed (AVDRMLayerDescriptor* p0 = &_0) { var a = new AVDRMLayerDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMLayerDescriptor[] array)
+    {
+        fixed (AVDRMLayerDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMLayerDescriptor[](AVDRMLayerDescriptor_array4 @struct) => @struct.ToArray();
+}
+
+public unsafe struct AVDRMObjectDescriptor_array4 : IFixedArray<AVDRMObjectDescriptor>
+{
+    public static readonly int Size = 4;
+    public int Length => 4;
+    AVDRMObjectDescriptor _0; AVDRMObjectDescriptor _1; AVDRMObjectDescriptor _2; AVDRMObjectDescriptor _3;
+    
+    public AVDRMObjectDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMObjectDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMObjectDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMObjectDescriptor[] ToArray()
+    {
+        fixed (AVDRMObjectDescriptor* p0 = &_0) { var a = new AVDRMObjectDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMObjectDescriptor[] array)
+    {
+        fixed (AVDRMObjectDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMObjectDescriptor[](AVDRMObjectDescriptor_array4 @struct) => @struct.ToArray();
+}
+
+public unsafe struct AVDRMPlaneDescriptor_array4 : IFixedArray<AVDRMPlaneDescriptor>
+{
+    public static readonly int Size = 4;
+    public int Length => 4;
+    AVDRMPlaneDescriptor _0; AVDRMPlaneDescriptor _1; AVDRMPlaneDescriptor _2; AVDRMPlaneDescriptor _3;
+    
+    public AVDRMPlaneDescriptor this[uint i]
+    {
+        get { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMPlaneDescriptor* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 4) throw new ArgumentOutOfRangeException(); fixed (AVDRMPlaneDescriptor* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public AVDRMPlaneDescriptor[] ToArray()
+    {
+        fixed (AVDRMPlaneDescriptor* p0 = &_0) { var a = new AVDRMPlaneDescriptor[4]; for (uint i = 0; i < 4; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(AVDRMPlaneDescriptor[] array)
+    {
+        fixed (AVDRMPlaneDescriptor* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 4) return; } }
+    }
+    public static implicit operator AVDRMPlaneDescriptor[](AVDRMPlaneDescriptor_array4 @struct) => @struct.ToArray();
+}
+
 public unsafe struct byte_ptrArray4 : IFixedArray
 {
     public static readonly int Size = 4;
@@ -442,6 +508,28 @@ public unsafe struct byte_array6 : IFixedArray<byte>
     public static implicit operator byte[](byte_array6 @struct) => @struct.ToArray();
 }
 
+public unsafe struct byte_array6x12 : IFixedArray<byte_array12>
+{
+    public static readonly int Size = 6;
+    public int Length => 6;
+    byte_array12 _0; byte_array12 _1; byte_array12 _2; byte_array12 _3; byte_array12 _4; byte_array12 _5;
+    
+    public byte_array12 this[uint i]
+    {
+        get { if (i >= 6) throw new ArgumentOutOfRangeException(); fixed (byte_array12* p0 = &_0) { return *(p0 + i); } }
+        set { if (i >= 6) throw new ArgumentOutOfRangeException(); fixed (byte_array12* p0 = &_0) { *(p0 + i) = value;  } }
+    }
+    public byte_array12[] ToArray()
+    {
+        fixed (byte_array12* p0 = &_0) { var a = new byte_array12[6]; for (uint i = 0; i < 6; i++) a[i] = *(p0 + i); return a; }
+    }
+    public void UpdateFrom(byte_array12[] array)
+    {
+        fixed (byte_array12* p0 = &_0) { uint i = 0; foreach(var value in array) { *(p0 + i++) = value; if (i >= 6) return; } }
+    }
+    public static implicit operator byte_array12[](byte_array6x12 @struct) => @struct.ToArray();
+}
+
 public unsafe struct ushort_array6 : IFixedArray<ushort>
 {
     public static readonly int Size = 6;
@@ -638,6 +726,28 @@ public unsafe struct int_array9 : IFixedArray<int>
         uint i = 0; foreach(var value in array) { _[i++] = value; if (i >= 9) return; }
     }
     public static implicit operator int[](int_array9 @struct) => @struct.ToArray();
+}
+
+public unsafe struct byte_array12 : IFixedArray<byte>
+{
+    public static readonly int Size = 12;
+    public int Length => 12;
+    fixed byte _[12];
+    
+    public byte this[uint i]
+    {
+        get => _[i];
+        set => _[i] = value;
+    }
+    public byte[] ToArray()
+    {
+        var a = new byte[12]; for (uint i = 0; i < 12; i++) a[i] = _[i]; return a;
+    }
+    public void UpdateFrom(byte[] array)
+    {
+        uint i = 0; foreach(var value in array) { _[i++] = value; if (i >= 12) return; }
+    }
+    public static implicit operator byte[](byte_array12 @struct) => @struct.ToArray();
 }
 
 public unsafe struct AVHDRPlusPercentile_array15 : IFixedArray<AVHDRPlusPercentile>

--- a/FFmpeg.AutoGen/generated/Delegates.g.cs
+++ b/FFmpeg.AutoGen/generated/Delegates.g.cs
@@ -41,6 +41,38 @@ public unsafe struct av_buffer_pool_init2_pool_free_func
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_and_eval_funcs1 (void* @p0, double @p1);
+public unsafe struct av_expr_parse_and_eval_funcs1_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_and_eval_funcs1_func(av_expr_parse_and_eval_funcs1 func) => new av_expr_parse_and_eval_funcs1_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_and_eval_funcs2 (void* @p0, double @p1, double @p2);
+public unsafe struct av_expr_parse_and_eval_funcs2_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_and_eval_funcs2_func(av_expr_parse_and_eval_funcs2 func) => new av_expr_parse_and_eval_funcs2_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_funcs1 (void* @p0, double @p1);
+public unsafe struct av_expr_parse_funcs1_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_funcs1_func(av_expr_parse_funcs1 func) => new av_expr_parse_funcs1_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate double av_expr_parse_funcs2 (void* @p0, double @p1, double @p2);
+public unsafe struct av_expr_parse_funcs2_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_expr_parse_funcs2_func(av_expr_parse_funcs2 func) => new av_expr_parse_funcs2_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void av_log_set_callback_callback (void* @p0, int @p1,     
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -84,6 +116,14 @@ public unsafe struct av_tree_insert_cmp_func
 {
     public IntPtr Pointer;
     public static implicit operator av_tree_insert_cmp_func(av_tree_insert_cmp func) => new av_tree_insert_cmp_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public unsafe delegate void av_tx_init_tx (AVTXContext* @s, void* @out, void* @in, long @stride);
+public unsafe struct av_tx_init_tx_func
+{
+    public IntPtr Pointer;
+    public static implicit operator av_tx_init_tx_func(av_tx_init_tx func) => new av_tx_init_tx_func { Pointer = func == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(func) };
 }
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/FFmpeg.AutoGen/generated/DynamicallyLoadedBindings.g.cs
+++ b/FFmpeg.AutoGen/generated/DynamicallyLoadedBindings.g.cs
@@ -48,6 +48,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_append_packet(@s, @pkt, @size);
         };
         
+        vectors.av_assert0_fpu = () =>
+        {
+            vectors.av_assert0_fpu = FunctionResolver.GetFunctionDelegate<vectors.av_assert0_fpu_delegate>("avutil", "av_assert0_fpu", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_assert0_fpu();
+        };
+        
         vectors.av_audio_fifo_alloc = (AVSampleFormat @sample_fmt, int @channels, int @nb_samples) =>
         {
             vectors.av_audio_fifo_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_audio_fifo_alloc_delegate>("avutil", "av_audio_fifo_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -978,6 +984,168 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_dynarray2_add(@tab_ptr, @nb_ptr, @elem_size, @elem_data);
         };
         
+        vectors.av_encryption_info_add_side_data = (AVEncryptionInfo* @info, ulong* @side_data_size) =>
+        {
+            vectors.av_encryption_info_add_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_add_side_data_delegate>("avutil", "av_encryption_info_add_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_add_side_data(@info, @side_data_size);
+        };
+        
+        vectors.av_encryption_info_alloc = (uint @subsample_count, uint @key_id_size, uint @iv_size) =>
+        {
+            vectors.av_encryption_info_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_alloc_delegate>("avutil", "av_encryption_info_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_alloc(@subsample_count, @key_id_size, @iv_size);
+        };
+        
+        vectors.av_encryption_info_clone = (AVEncryptionInfo* @info) =>
+        {
+            vectors.av_encryption_info_clone = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_clone_delegate>("avutil", "av_encryption_info_clone", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_clone(@info);
+        };
+        
+        vectors.av_encryption_info_free = (AVEncryptionInfo* @info) =>
+        {
+            vectors.av_encryption_info_free = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_free_delegate>("avutil", "av_encryption_info_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_encryption_info_free(@info);
+        };
+        
+        vectors.av_encryption_info_get_side_data = (byte* @side_data, ulong @side_data_size) =>
+        {
+            vectors.av_encryption_info_get_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_info_get_side_data_delegate>("avutil", "av_encryption_info_get_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_info_get_side_data(@side_data, @side_data_size);
+        };
+        
+        vectors.av_encryption_init_info_add_side_data = (AVEncryptionInitInfo* @info, ulong* @side_data_size) =>
+        {
+            vectors.av_encryption_init_info_add_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_add_side_data_delegate>("avutil", "av_encryption_init_info_add_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_add_side_data(@info, @side_data_size);
+        };
+        
+        vectors.av_encryption_init_info_alloc = (uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size) =>
+        {
+            vectors.av_encryption_init_info_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_alloc_delegate>("avutil", "av_encryption_init_info_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_alloc(@system_id_size, @num_key_ids, @key_id_size, @data_size);
+        };
+        
+        vectors.av_encryption_init_info_free = (AVEncryptionInitInfo* @info) =>
+        {
+            vectors.av_encryption_init_info_free = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_free_delegate>("avutil", "av_encryption_init_info_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_encryption_init_info_free(@info);
+        };
+        
+        vectors.av_encryption_init_info_get_side_data = (byte* @side_data, ulong @side_data_size) =>
+        {
+            vectors.av_encryption_init_info_get_side_data = FunctionResolver.GetFunctionDelegate<vectors.av_encryption_init_info_get_side_data_delegate>("avutil", "av_encryption_init_info_get_side_data", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_encryption_init_info_get_side_data(@side_data, @side_data_size);
+        };
+        
+        vectors.av_exif_clone_ifd = (AVExifMetadata* @ifd) =>
+        {
+            vectors.av_exif_clone_ifd = FunctionResolver.GetFunctionDelegate<vectors.av_exif_clone_ifd_delegate>("avcodec", "av_exif_clone_ifd", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_clone_ifd(@ifd);
+        };
+        
+        vectors.av_exif_free = (AVExifMetadata* @ifd) =>
+        {
+            vectors.av_exif_free = FunctionResolver.GetFunctionDelegate<vectors.av_exif_free_delegate>("avcodec", "av_exif_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_exif_free(@ifd);
+        };
+        
+        vectors.av_exif_get_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value) =>
+        {
+            vectors.av_exif_get_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_entry_delegate>("avcodec", "av_exif_get_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_entry(@logctx, @ifd, @id, @flags, @value);
+        };
+        
+        vectors.av_exif_get_tag_id = (string @name) =>
+        {
+            vectors.av_exif_get_tag_id = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_tag_id_delegate>("avcodec", "av_exif_get_tag_id", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_tag_id(@name);
+        };
+        
+        vectors.av_exif_get_tag_name = (ushort @id) =>
+        {
+            vectors.av_exif_get_tag_name = FunctionResolver.GetFunctionDelegate<vectors.av_exif_get_tag_name_delegate>("avcodec", "av_exif_get_tag_name", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_get_tag_name(@id);
+        };
+        
+        vectors.av_exif_ifd_to_dict = (void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata) =>
+        {
+            vectors.av_exif_ifd_to_dict = FunctionResolver.GetFunctionDelegate<vectors.av_exif_ifd_to_dict_delegate>("avcodec", "av_exif_ifd_to_dict", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_ifd_to_dict(@logctx, @ifd, @metadata);
+        };
+        
+        vectors.av_exif_matrix_to_orientation = (int* @matrix) =>
+        {
+            vectors.av_exif_matrix_to_orientation = FunctionResolver.GetFunctionDelegate<vectors.av_exif_matrix_to_orientation_delegate>("avcodec", "av_exif_matrix_to_orientation", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_matrix_to_orientation(@matrix);
+        };
+        
+        vectors.av_exif_orientation_to_matrix = (int* @matrix, int @orientation) =>
+        {
+            vectors.av_exif_orientation_to_matrix = FunctionResolver.GetFunctionDelegate<vectors.av_exif_orientation_to_matrix_delegate>("avcodec", "av_exif_orientation_to_matrix", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_orientation_to_matrix(@matrix, @orientation);
+        };
+        
+        vectors.av_exif_parse_buffer = (void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode) =>
+        {
+            vectors.av_exif_parse_buffer = FunctionResolver.GetFunctionDelegate<vectors.av_exif_parse_buffer_delegate>("avcodec", "av_exif_parse_buffer", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_parse_buffer(@logctx, @data, @size, @ifd, @header_mode);
+        };
+        
+        vectors.av_exif_remove_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags) =>
+        {
+            vectors.av_exif_remove_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_remove_entry_delegate>("avcodec", "av_exif_remove_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_remove_entry(@logctx, @ifd, @id, @flags);
+        };
+        
+        vectors.av_exif_set_entry = (void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value) =>
+        {
+            vectors.av_exif_set_entry = FunctionResolver.GetFunctionDelegate<vectors.av_exif_set_entry_delegate>("avcodec", "av_exif_set_entry", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_set_entry(@logctx, @ifd, @id, @type, @count, @ifd_lead, @ifd_offset, @value);
+        };
+        
+        vectors.av_exif_write = (void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode) =>
+        {
+            vectors.av_exif_write = FunctionResolver.GetFunctionDelegate<vectors.av_exif_write_delegate>("avcodec", "av_exif_write", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_exif_write(@logctx, @ifd, @buffer, @header_mode);
+        };
+        
+        vectors.av_expr_count_func = (AVExpr* @e, uint* @counter, int @size, int @arg) =>
+        {
+            vectors.av_expr_count_func = FunctionResolver.GetFunctionDelegate<vectors.av_expr_count_func_delegate>("avutil", "av_expr_count_func", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_count_func(@e, @counter, @size, @arg);
+        };
+        
+        vectors.av_expr_count_vars = (AVExpr* @e, uint* @counter, int @size) =>
+        {
+            vectors.av_expr_count_vars = FunctionResolver.GetFunctionDelegate<vectors.av_expr_count_vars_delegate>("avutil", "av_expr_count_vars", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_count_vars(@e, @counter, @size);
+        };
+        
+        vectors.av_expr_eval = (AVExpr* @e, double* @const_values, void* @opaque) =>
+        {
+            vectors.av_expr_eval = FunctionResolver.GetFunctionDelegate<vectors.av_expr_eval_delegate>("avutil", "av_expr_eval", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_eval(@e, @const_values, @opaque);
+        };
+        
+        vectors.av_expr_free = (AVExpr* @e) =>
+        {
+            vectors.av_expr_free = FunctionResolver.GetFunctionDelegate<vectors.av_expr_free_delegate>("avutil", "av_expr_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_expr_free(@e);
+        };
+        
+        vectors.av_expr_parse = (AVExpr** @expr, string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_expr_parse = FunctionResolver.GetFunctionDelegate<vectors.av_expr_parse_delegate>("avutil", "av_expr_parse", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_parse(@expr, @s, @const_names, @func1_names, @funcs1, @func2_names, @funcs2, @log_offset, @log_ctx);
+        };
+        
+        vectors.av_expr_parse_and_eval = (double* @res, string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_expr_parse_and_eval = FunctionResolver.GetFunctionDelegate<vectors.av_expr_parse_and_eval_delegate>("avutil", "av_expr_parse_and_eval", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_expr_parse_and_eval(@res, @s, @const_names, @const_values, @func1_names, @funcs1, @func2_names, @funcs2, @opaque, @log_offset, @log_ctx);
+        };
+        
         vectors.av_fast_malloc = (void* @ptr, uint* @size, ulong @min_size) =>
         {
             vectors.av_fast_malloc = FunctionResolver.GetFunctionDelegate<vectors.av_fast_malloc_delegate>("avutil", "av_fast_malloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -1048,6 +1216,12 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_find_default_stream_index = FunctionResolver.GetFunctionDelegate<vectors.av_find_default_stream_index_delegate>("avformat", "av_find_default_stream_index", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_find_default_stream_index(@s);
+        };
+        
+        vectors.av_find_info_tag = (byte* @arg, int @arg_size, string @tag1, string @info) =>
+        {
+            vectors.av_find_info_tag = FunctionResolver.GetFunctionDelegate<vectors.av_find_info_tag_delegate>("avutil", "av_find_info_tag", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_find_info_tag(@arg, @arg_size, @tag1, @info);
         };
         
         vectors.av_find_input_format = (string @short_name) =>
@@ -1326,6 +1500,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_get_frame_filename2(@buf, @buf_size, @path, @number, @flags);
         };
         
+        vectors.av_get_known_color_name = (int @color_idx, byte** @rgb) =>
+        {
+            vectors.av_get_known_color_name = FunctionResolver.GetFunctionDelegate<vectors.av_get_known_color_name_delegate>("avutil", "av_get_known_color_name", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_get_known_color_name(@color_idx, @rgb);
+        };
+        
         vectors.av_get_media_type_string = (AVMediaType @media_type) =>
         {
             vectors.av_get_media_type_string = FunctionResolver.GetFunctionDelegate<vectors.av_get_media_type_string_delegate>("avutil", "av_get_media_type_string", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -1594,6 +1774,78 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_hwframe_transfer_get_formats = FunctionResolver.GetFunctionDelegate<vectors.av_hwframe_transfer_get_formats_delegate>("avutil", "av_hwframe_transfer_get_formats", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_hwframe_transfer_get_formats(@hwframe_ctx, @dir, @formats, @flags);
+        };
+        
+        vectors.av_iamf_audio_element_add_layer = (AVIAMFAudioElement* @audio_element) =>
+        {
+            vectors.av_iamf_audio_element_add_layer = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_add_layer_delegate>("avutil", "av_iamf_audio_element_add_layer", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_add_layer(@audio_element);
+        };
+        
+        vectors.av_iamf_audio_element_alloc = () =>
+        {
+            vectors.av_iamf_audio_element_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_alloc_delegate>("avutil", "av_iamf_audio_element_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_alloc();
+        };
+        
+        vectors.av_iamf_audio_element_free = (AVIAMFAudioElement** @audio_element) =>
+        {
+            vectors.av_iamf_audio_element_free = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_free_delegate>("avutil", "av_iamf_audio_element_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_iamf_audio_element_free(@audio_element);
+        };
+        
+        vectors.av_iamf_audio_element_get_class = () =>
+        {
+            vectors.av_iamf_audio_element_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_audio_element_get_class_delegate>("avutil", "av_iamf_audio_element_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_audio_element_get_class();
+        };
+        
+        vectors.av_iamf_mix_presentation_add_submix = (AVIAMFMixPresentation* @mix_presentation) =>
+        {
+            vectors.av_iamf_mix_presentation_add_submix = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_add_submix_delegate>("avutil", "av_iamf_mix_presentation_add_submix", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_add_submix(@mix_presentation);
+        };
+        
+        vectors.av_iamf_mix_presentation_alloc = () =>
+        {
+            vectors.av_iamf_mix_presentation_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_alloc_delegate>("avutil", "av_iamf_mix_presentation_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_alloc();
+        };
+        
+        vectors.av_iamf_mix_presentation_free = (AVIAMFMixPresentation** @mix_presentation) =>
+        {
+            vectors.av_iamf_mix_presentation_free = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_free_delegate>("avutil", "av_iamf_mix_presentation_free", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_iamf_mix_presentation_free(@mix_presentation);
+        };
+        
+        vectors.av_iamf_mix_presentation_get_class = () =>
+        {
+            vectors.av_iamf_mix_presentation_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_mix_presentation_get_class_delegate>("avutil", "av_iamf_mix_presentation_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_mix_presentation_get_class();
+        };
+        
+        vectors.av_iamf_param_definition_alloc = (AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size) =>
+        {
+            vectors.av_iamf_param_definition_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_param_definition_alloc_delegate>("avutil", "av_iamf_param_definition_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_param_definition_alloc(@type, @nb_subblocks, @size);
+        };
+        
+        vectors.av_iamf_param_definition_get_class = () =>
+        {
+            vectors.av_iamf_param_definition_get_class = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_param_definition_get_class_delegate>("avutil", "av_iamf_param_definition_get_class", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_param_definition_get_class();
+        };
+        
+        vectors.av_iamf_submix_add_element = (AVIAMFSubmix* @submix) =>
+        {
+            vectors.av_iamf_submix_add_element = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_submix_add_element_delegate>("avutil", "av_iamf_submix_add_element", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_submix_add_element(@submix);
+        };
+        
+        vectors.av_iamf_submix_add_layout = (AVIAMFSubmix* @submix) =>
+        {
+            vectors.av_iamf_submix_add_layout = FunctionResolver.GetFunctionDelegate<vectors.av_iamf_submix_add_layout_delegate>("avutil", "av_iamf_submix_add_layout", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_iamf_submix_add_layout(@submix);
         };
         
         vectors.av_image_alloc = (ref byte_ptrArray4 @pointers, ref int_array4 @linesizes, int @w, int @h, AVPixelFormat @pix_fmt, int @align) =>
@@ -2388,10 +2640,40 @@ public static unsafe partial class DynamicallyLoadedBindings
             vectors.av_packet_unref(@pkt);
         };
         
+        vectors.av_parse_color = (byte* @rgba_color, string @color_string, int @slen, void* @log_ctx) =>
+        {
+            vectors.av_parse_color = FunctionResolver.GetFunctionDelegate<vectors.av_parse_color_delegate>("avutil", "av_parse_color", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_color(@rgba_color, @color_string, @slen, @log_ctx);
+        };
+        
         vectors.av_parse_cpu_caps = (uint* @flags, string @s) =>
         {
             vectors.av_parse_cpu_caps = FunctionResolver.GetFunctionDelegate<vectors.av_parse_cpu_caps_delegate>("avutil", "av_parse_cpu_caps", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_parse_cpu_caps(@flags, @s);
+        };
+        
+        vectors.av_parse_ratio = (AVRational* @q, string @str, int @max, int @log_offset, void* @log_ctx) =>
+        {
+            vectors.av_parse_ratio = FunctionResolver.GetFunctionDelegate<vectors.av_parse_ratio_delegate>("avutil", "av_parse_ratio", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_ratio(@q, @str, @max, @log_offset, @log_ctx);
+        };
+        
+        vectors.av_parse_time = (long* @timeval, string @timestr, int @duration) =>
+        {
+            vectors.av_parse_time = FunctionResolver.GetFunctionDelegate<vectors.av_parse_time_delegate>("avutil", "av_parse_time", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_time(@timeval, @timestr, @duration);
+        };
+        
+        vectors.av_parse_video_rate = (AVRational* @rate, string @str) =>
+        {
+            vectors.av_parse_video_rate = FunctionResolver.GetFunctionDelegate<vectors.av_parse_video_rate_delegate>("avutil", "av_parse_video_rate", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_video_rate(@rate, @str);
+        };
+        
+        vectors.av_parse_video_size = (int* @width_ptr, int* @height_ptr, string @str) =>
+        {
+            vectors.av_parse_video_size = FunctionResolver.GetFunctionDelegate<vectors.av_parse_video_size_delegate>("avutil", "av_parse_video_size", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_parse_video_size(@width_ptr, @height_ptr, @str);
         };
         
         vectors.av_parser_close = (AVCodecParserContext* @s) =>
@@ -2688,6 +2970,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_size_mult(@a, @b, @r);
         };
         
+        vectors.av_small_strptime = (string @p, string @fmt, tm* @dt) =>
+        {
+            vectors.av_small_strptime = FunctionResolver.GetFunctionDelegate<vectors.av_small_strptime_delegate>("avutil", "av_small_strptime", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_small_strptime(@p, @fmt, @dt);
+        };
+        
         vectors.av_strdup = (string @s) =>
         {
             vectors.av_strdup = FunctionResolver.GetFunctionDelegate<vectors.av_strdup_delegate>("avutil", "av_strdup", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -2722,6 +3010,12 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_strndup = FunctionResolver.GetFunctionDelegate<vectors.av_strndup_delegate>("avutil", "av_strndup", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_strndup(@s, @len);
+        };
+        
+        vectors.av_strtod = (string @numstr, byte** @tail) =>
+        {
+            vectors.av_strtod = FunctionResolver.GetFunctionDelegate<vectors.av_strtod_delegate>("avutil", "av_strtod", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_strtod(@numstr, @tail);
         };
         
         vectors.av_sub_q = (AVRational @b, AVRational @c) =>
@@ -2796,6 +3090,12 @@ public static unsafe partial class DynamicallyLoadedBindings
             return vectors.av_timecode_make_string(@tc, @buf, @framenum);
         };
         
+        vectors.av_timegm = (tm* @tm) =>
+        {
+            vectors.av_timegm = FunctionResolver.GetFunctionDelegate<vectors.av_timegm_delegate>("avutil", "av_timegm", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_timegm(@tm);
+        };
+        
         vectors.av_tree_destroy = (AVTreeNode* @t) =>
         {
             vectors.av_tree_destroy = FunctionResolver.GetFunctionDelegate<vectors.av_tree_destroy_delegate>("avutil", "av_tree_destroy", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
@@ -2824,6 +3124,18 @@ public static unsafe partial class DynamicallyLoadedBindings
         {
             vectors.av_tree_node_alloc = FunctionResolver.GetFunctionDelegate<vectors.av_tree_node_alloc_delegate>("avutil", "av_tree_node_alloc", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
             return vectors.av_tree_node_alloc();
+        };
+        
+        vectors.av_tx_init = (AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags) =>
+        {
+            vectors.av_tx_init = FunctionResolver.GetFunctionDelegate<vectors.av_tx_init_delegate>("avutil", "av_tx_init", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            return vectors.av_tx_init(@ctx, @tx, @type, @inv, @len, @scale, @flags);
+        };
+        
+        vectors.av_tx_uninit = (AVTXContext** @ctx) =>
+        {
+            vectors.av_tx_uninit = FunctionResolver.GetFunctionDelegate<vectors.av_tx_uninit_delegate>("avutil", "av_tx_uninit", ThrowErrorIfFunctionNotFound) ?? delegate { throw new NotSupportedException(); };
+            vectors.av_tx_uninit(@ctx);
         };
         
         vectors.av_url_split = (byte* @proto, int @proto_size, byte* @authorization, int @authorization_size, byte* @hostname, int @hostname_size, int* @port_ptr, byte* @path, int @path_size, string @url) =>

--- a/FFmpeg.AutoGen/generated/Enums.g.cs
+++ b/FFmpeg.AutoGen/generated/Enums.g.cs
@@ -1009,6 +1009,13 @@ public enum AVDiscard : int
     @AVDISCARD_ALL = 48,
 }
 
+/// <summary>API-specific header for AV_HWDEVICE_TYPE_DRM.</summary>
+public enum AvDrmMax : int
+{
+    /// <summary>The maximum number of layers/planes in a DRM frame.</summary>
+    @AV_DRM_MAX_PLANES = 4,
+}
+
 /// <summary>The duration of a video can be estimated through various ways, and this enum can be used to know how the duration was estimated.</summary>
 public enum AVDurationEstimationMethod : int
 {
@@ -1018,6 +1025,20 @@ public enum AVDurationEstimationMethod : int
     @AVFMT_DURATION_FROM_STREAM = 1,
     /// <summary>Duration estimated from bitrate (less accurate)</summary>
     @AVFMT_DURATION_FROM_BITRATE = 2,
+}
+
+public enum AVExifHeaderMode : int
+{
+    /// <summary>The TIFF header starts with 0x49492a00, or 0x4d4d002a. This one is used internally by FFmpeg.</summary>
+    @AV_EXIF_TIFF_HEADER = 0,
+    /// <summary>skip the TIFF header, assume little endian</summary>
+    @AV_EXIF_ASSUME_LE = 1,
+    /// <summary>skip the TIFF header, assume big endian</summary>
+    @AV_EXIF_ASSUME_BE = 2,
+    /// <summary>The first four bytes point to the actual start, then it&apos;s AV_EXIF_TIFF_HEADER</summary>
+    @AV_EXIF_T_OFF = 3,
+    /// <summary>The first six bytes contain &quot;Exif\0\0&quot;, then it&apos;s AV_EXIF_TIFF_HEADER</summary>
+    @AV_EXIF_EXIF00 = 4,
 }
 
 public enum AVFieldOrder : int
@@ -1180,6 +1201,54 @@ public enum AVHWFrameTransferDirection : int
     @AV_HWFRAME_TRANSFER_DIRECTION_FROM = 0,
     /// <summary>Transfer the data to the queried hw frame.</summary>
     @AV_HWFRAME_TRANSFER_DIRECTION_TO = 1,
+}
+
+/// <summary>@} @{</summary>
+public enum AVIAMFAmbisonicsMode : int
+{
+    @AV_IAMF_AMBISONICS_MODE_MONO = 0,
+    @AV_IAMF_AMBISONICS_MODE_PROJECTION = 1,
+}
+
+/// <summary>Immersive Audio Model and Formats related functions and defines</summary>
+public enum AVIAMFAnimationType : int
+{
+    @AV_IAMF_ANIMATION_TYPE_STEP = 0,
+    @AV_IAMF_ANIMATION_TYPE_LINEAR = 1,
+    @AV_IAMF_ANIMATION_TYPE_BEZIER = 2,
+}
+
+public enum AVIAMFAudioElementType : int
+{
+    @AV_IAMF_AUDIO_ELEMENT_TYPE_CHANNEL = 0,
+    @AV_IAMF_AUDIO_ELEMENT_TYPE_SCENE = 1,
+}
+
+/// <summary>@} @{</summary>
+public enum AVIAMFHeadphonesMode : int
+{
+    /// <summary>The referenced Audio Element shall be rendered to stereo loudspeakers.</summary>
+    @AV_IAMF_HEADPHONES_MODE_STEREO = 0,
+    /// <summary>The referenced Audio Element shall be rendered with a binaural renderer.</summary>
+    @AV_IAMF_HEADPHONES_MODE_BINAURAL = 1,
+}
+
+public enum AVIAMFParamDefinitionType : int
+{
+    /// <summary>Subblocks are of struct type AVIAMFMixGain</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN = 0,
+    /// <summary>Subblocks are of struct type AVIAMFDemixingInfo</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_DEMIXING = 1,
+    /// <summary>Subblocks are of struct type AVIAMFReconGain</summary>
+    @AV_IAMF_PARAMETER_DEFINITION_RECON_GAIN = 2,
+}
+
+public enum AVIAMFSubmixLayoutType : int
+{
+    /// <summary>The layout follows the loudspeaker sound system convention of ITU-2051-3. AVIAMFSubmixLayout.sound_system must be set.</summary>
+    @AV_IAMF_SUBMIX_LAYOUT_TYPE_LOUDSPEAKERS = 2,
+    /// <summary>The layout is binaural.</summary>
+    @AV_IAMF_SUBMIX_LAYOUT_TYPE_BINAURAL = 3,
 }
 
 /// <summary>Different data types that can be returned via the AVIO write_data_type callback.</summary>
@@ -2076,6 +2145,24 @@ public enum AVSubtitleType : int
     @SUBTITLE_ASS = 3,
 }
 
+/// <summary>Data type identifiers for TIFF tags</summary>
+public enum AVTiffDataType : int
+{
+    @AV_TIFF_BYTE = 1,
+    @AV_TIFF_STRING = 2,
+    @AV_TIFF_SHORT = 3,
+    @AV_TIFF_LONG = 4,
+    @AV_TIFF_RATIONAL = 5,
+    @AV_TIFF_SBYTE = 6,
+    @AV_TIFF_UNDEFINED = 7,
+    @AV_TIFF_SSHORT = 8,
+    @AV_TIFF_SLONG = 9,
+    @AV_TIFF_SRATIONAL = 10,
+    @AV_TIFF_FLOAT = 11,
+    @AV_TIFF_DOUBLE = 12,
+    @AV_TIFF_IFD = 13,
+}
+
 public enum AVTimecodeFlag : int
 {
     /// <summary>timecode is drop frame</summary>
@@ -2084,6 +2171,63 @@ public enum AVTimecodeFlag : int
     @AV_TIMECODE_FLAG_24HOURSMAX = 2,
     /// <summary>negative time values are allowed</summary>
     @AV_TIMECODE_FLAG_ALLOWNEGATIVE = 4,
+}
+
+/// <summary>Flags for av_tx_init()</summary>
+public enum AVTXFlags : int
+{
+    /// <summary>Allows for in-place transformations, where input == output. May be unsupported or slower for some transform types.</summary>
+    @AV_TX_INPLACE = 1,
+    /// <summary>Relaxes alignment requirement for the in and out arrays of av_tx_fn(). May be slower with certain transform types.</summary>
+    @AV_TX_UNALIGNED = 2,
+    /// <summary>Performs a full inverse MDCT rather than leaving out samples that can be derived through symmetry. Requires an output array of &apos;len&apos; floats, rather than the usual &apos;len/2&apos; floats. Ignored for all transforms but inverse MDCTs.</summary>
+    @AV_TX_FULL_IMDCT = 4,
+    /// <summary>Perform a real to half-complex RDFT. Only the real, or imaginary coefficients will be output, depending on the flag used. Only available for forward RDFTs. Output array must have enough space to hold N complex values (regular size for a real to complex transform).</summary>
+    @AV_TX_REAL_TO_REAL = 8,
+    /// <summary>Perform a real to half-complex RDFT. Only the real, or imaginary coefficients will be output, depending on the flag used. Only available for forward RDFTs. Output array must have enough space to hold N complex values (regular size for a real to complex transform).</summary>
+    @AV_TX_REAL_TO_IMAGINARY = 16,
+}
+
+public enum AVTXType : int
+{
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_FLOAT_FFT = 0,
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_DOUBLE_FFT = 2,
+    /// <summary>Standard complex to complex FFT with sample data type of AVComplexFloat, AVComplexDouble or AVComplexInt32, for each respective variant.</summary>
+    @AV_TX_INT32_FFT = 4,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_FLOAT_MDCT = 1,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_DOUBLE_MDCT = 3,
+    /// <summary>Standard MDCT with a sample data type of float, double or int32_t, respectively. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_INT32_MDCT = 5,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_FLOAT_RDFT = 6,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_DOUBLE_RDFT = 7,
+    /// <summary>Real to complex and complex to real DFTs. For the float and int32 variants, the scale type is &apos;float&apos;, while for the double variant, it&apos;s a &apos;double&apos;. If scale is NULL, 1.0 will be used as a default.</summary>
+    @AV_TX_INT32_RDFT = 8,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_FLOAT_DCT = 9,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_DOUBLE_DCT = 10,
+    /// <summary>Real to real (DCT) transforms.</summary>
+    @AV_TX_INT32_DCT = 11,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_FLOAT_DCT_I = 12,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_DOUBLE_DCT_I = 13,
+    /// <summary>Discrete Cosine Transform I</summary>
+    @AV_TX_INT32_DCT_I = 14,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_FLOAT_DST_I = 15,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_DOUBLE_DST_I = 16,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_INT32_DST_I = 17,
+    /// <summary>Discrete Sine Transform I</summary>
+    @AV_TX_NB = 18,
 }
 
 /// <summary>Dithering algorithms</summary>

--- a/FFmpeg.AutoGen/generated/Structs.g.cs
+++ b/FFmpeg.AutoGen/generated/Structs.g.cs
@@ -632,6 +632,24 @@ public unsafe partial struct AVCodecParserContext
     public int @format;
 }
 
+public unsafe partial struct AVComplexDouble
+{
+    public double @re;
+    public double @im;
+}
+
+public unsafe partial struct AVComplexFloat
+{
+    public float @re;
+    public float @im;
+}
+
+public unsafe partial struct AVComplexInt32
+{
+    public int @re;
+    public int @im;
+}
+
 public unsafe partial struct AVComponentDescriptor
 {
     /// <summary>Which of the 4 planes contains the component.</summary>
@@ -777,6 +795,59 @@ public unsafe partial struct AVDictionaryEntry
     public byte* @value;
 }
 
+/// <summary>DRM device.</summary>
+public unsafe partial struct AVDRMDeviceContext
+{
+    /// <summary>File descriptor of DRM device.</summary>
+    public int @fd;
+}
+
+/// <summary>DRM frame descriptor.</summary>
+public unsafe partial struct AVDRMFrameDescriptor
+{
+    /// <summary>Number of DRM objects making up this frame.</summary>
+    public int @nb_objects;
+    /// <summary>Array of objects making up the frame.</summary>
+    public AVDRMObjectDescriptor_array4 @objects;
+    /// <summary>Number of layers in the frame.</summary>
+    public int @nb_layers;
+    /// <summary>Array of layers in the frame.</summary>
+    public AVDRMLayerDescriptor_array4 @layers;
+}
+
+/// <summary>DRM layer descriptor.</summary>
+public unsafe partial struct AVDRMLayerDescriptor
+{
+    /// <summary>Format of the layer (DRM_FORMAT_*).</summary>
+    public uint @format;
+    /// <summary>Number of planes in the layer.</summary>
+    public int @nb_planes;
+    /// <summary>Array of planes in this layer.</summary>
+    public AVDRMPlaneDescriptor_array4 @planes;
+}
+
+/// <summary>DRM object descriptor.</summary>
+public unsafe partial struct AVDRMObjectDescriptor
+{
+    /// <summary>DRM PRIME fd for the object.</summary>
+    public int @fd;
+    /// <summary>Total size of the object.</summary>
+    public ulong @size;
+    /// <summary>Format modifier applied to the object (DRM_FORMAT_MOD_*).</summary>
+    public ulong @format_modifier;
+}
+
+/// <summary>DRM plane descriptor.</summary>
+public unsafe partial struct AVDRMPlaneDescriptor
+{
+    /// <summary>Index of the object containing this plane in the objects array of the enclosing frame descriptor.</summary>
+    public int @object_index;
+    /// <summary>Offset within that object of this plane.</summary>
+    public long @offset;
+    /// <summary>Pitch (linesize) of this plane.</summary>
+    public long @pitch;
+}
+
 /// <summary>This struct is allocated as AVHWDeviceContext.hwctx</summary>
 public unsafe partial struct AVDXVA2DeviceContext
 {
@@ -855,6 +926,85 @@ public unsafe partial struct AVDynamicHDRSmpte2094App5
     public ushort_array4x32 @gain_curve_control_points_x;
     public ushort_array4x32 @gain_curve_control_points_y;
     public ushort_array4x32 @gain_curve_control_points_theta;
+}
+
+/// <summary>This describes encryption info for a packet. This contains frame-specific info for how to decrypt the packet before passing it to the decoder.</summary>
+public unsafe partial struct AVEncryptionInfo
+{
+    /// <summary>The fourcc encryption scheme, in big-endian byte order.</summary>
+    public uint @scheme;
+    /// <summary>Only used for pattern encryption. This is the number of 16-byte blocks that are encrypted.</summary>
+    public uint @crypt_byte_block;
+    /// <summary>Only used for pattern encryption. This is the number of 16-byte blocks that are clear.</summary>
+    public uint @skip_byte_block;
+    /// <summary>The ID of the key used to encrypt the packet. This should always be 16 bytes long, but may be changed in the future.</summary>
+    public byte* @key_id;
+    public uint @key_id_size;
+    /// <summary>The initialization vector. This may have been zero-filled to be the correct block size. This should always be 16 bytes long, but may be changed in the future.</summary>
+    public byte* @iv;
+    public uint @iv_size;
+    /// <summary>An array of subsample encryption info specifying how parts of the sample are encrypted. If there are no subsamples, then the whole sample is encrypted.</summary>
+    public AVSubsampleEncryptionInfo* @subsamples;
+    public uint @subsample_count;
+}
+
+/// <summary>This describes info used to initialize an encryption key system.</summary>
+public unsafe partial struct AVEncryptionInitInfo
+{
+    /// <summary>A unique identifier for the key system this is for, can be NULL if it is not known. This should always be 16 bytes, but may change in the future.</summary>
+    public byte* @system_id;
+    public uint @system_id_size;
+    /// <summary>An array of key IDs this initialization data is for. All IDs are the same length. Can be NULL if there are no known key IDs.</summary>
+    public byte** @key_ids;
+    /// <summary>The number of key IDs.</summary>
+    public uint @num_key_ids;
+    /// <summary>The number of bytes in each key ID. This should always be 16, but may change in the future.</summary>
+    public uint @key_id_size;
+    /// <summary>Key-system specific initialization data. This data is copied directly from the file and the format depends on the specific key system. This can be NULL if there is no initialization data; in that case, there will be at least one key ID.</summary>
+    public byte* @data;
+    public uint @data_size;
+    /// <summary>An optional pointer to the next initialization info in the list.</summary>
+    public AVEncryptionInitInfo* @next;
+}
+
+public unsafe partial struct AVExifEntry
+{
+    public ushort @id;
+    public AVTiffDataType @type;
+    public uint @count;
+    public uint @ifd_offset;
+    public byte* @ifd_lead;
+    public AVExifEntry_value @value;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct AVExifEntry_value
+{
+    [FieldOffset(0)]
+    public void* @ptr;
+    [FieldOffset(0)]
+    public long* @sint;
+    [FieldOffset(0)]
+    public ulong* @uint;
+    [FieldOffset(0)]
+    public double* @dbl;
+    [FieldOffset(0)]
+    public byte* @str;
+    [FieldOffset(0)]
+    public byte* @ubytes;
+    [FieldOffset(0)]
+    public sbyte* @sbytes;
+    [FieldOffset(0)]
+    public AVRational* @rat;
+    [FieldOffset(0)]
+    public AVExifMetadata @ifd;
+}
+
+public unsafe partial struct AVExifMetadata
+{
+    public AVExifEntry* @entries;
+    public uint @count;
+    public uint @size;
 }
 
 /// <summary>Filter definition. This defines the pads a filter contains, and all the callback functions used to interact with the filter.</summary>
@@ -1414,6 +1564,167 @@ public unsafe partial struct AVHWFramesContext
     public int @width;
     /// <summary>The allocated dimensions of the frames in this pool.</summary>
     public int @height;
+}
+
+/// <summary>Information on how to combine one or more audio streams, as defined in section 3.6 of IAMF.</summary>
+public unsafe partial struct AVIAMFAudioElement
+{
+    public AVClass* @av_class;
+    public AVIAMFLayer** @layers;
+    /// <summary>Number of layers, or channel groups, in the Audio Element. There may be 6 layers at most, and for audio_element_type AV_IAMF_AUDIO_ELEMENT_TYPE_SCENE, there may be exactly 1.</summary>
+    public uint @nb_layers;
+    /// <summary>Demixing information used to reconstruct a scalable channel audio representation. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_DEMIXING.</summary>
+    public AVIAMFParamDefinition* @demixing_info;
+    /// <summary>Recon gain information used to reconstruct a scalable channel audio representation. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_RECON_GAIN.</summary>
+    public AVIAMFParamDefinition* @recon_gain_info;
+    /// <summary>Audio element type as defined in section 3.6 of IAMF.</summary>
+    public AVIAMFAudioElementType @audio_element_type;
+    /// <summary>Default weight value as defined in section 3.6 of IAMF.</summary>
+    public uint @default_w;
+}
+
+/// <summary>Demixing Info Parameter Data as defined in section 3.8.2 of IAMF.</summary>
+public unsafe partial struct AVIAMFDemixingInfo
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>Pre-defined combination of demixing parameters.</summary>
+    public uint @dmixp_mode;
+}
+
+/// <summary>A layer defining a Channel Layout in the Audio Element.</summary>
+public unsafe partial struct AVIAMFLayer
+{
+    public AVClass* @av_class;
+    public AVChannelLayout @ch_layout;
+    /// <summary>A bitmask which may contain a combination of AV_IAMF_LAYER_FLAG_* flags.</summary>
+    public uint @flags;
+    /// <summary>Output gain channel flags as defined in section 3.6.2 of IAMF.</summary>
+    public uint @output_gain_flags;
+    /// <summary>Output gain as defined in section 3.6.2 of IAMF.</summary>
+    public AVRational @output_gain;
+    /// <summary>Ambisonics mode as defined in section 3.6.3 of IAMF.</summary>
+    public AVIAMFAmbisonicsMode @ambisonics_mode;
+    /// <summary>Demixing matrix as defined in section 3.6.3 of IAMF.</summary>
+    public AVRational* @demixing_matrix;
+    /// <summary>The length of the Demixing matrix array. Must be ch_layout.nb_channels multiplied by the sum of the amount of streams in the group plus the amount of streams in the group that are stereo.</summary>
+    public uint @nb_demixing_matrix;
+}
+
+/// <summary>Mix Gain Parameter Data as defined in section 3.8.1 of IAMF.</summary>
+public unsafe partial struct AVIAMFMixGain
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>The type of animation applied to the parameter values.</summary>
+    public AVIAMFAnimationType @animation_type;
+    /// <summary>Parameter value that is applied at the start of the subblock. Applies to all defined Animation Types.</summary>
+    public AVRational @start_point_value;
+    /// <summary>Parameter value that is applied at the end of the subblock. Applies only to AV_IAMF_ANIMATION_TYPE_LINEAR and AV_IAMF_ANIMATION_TYPE_BEZIER Animation Types.</summary>
+    public AVRational @end_point_value;
+    /// <summary>Parameter value of the middle control point of a quadratic Bezier curve, i.e., its y-axis value. Applies only to AV_IAMF_ANIMATION_TYPE_BEZIER Animation Type.</summary>
+    public AVRational @control_point_value;
+    /// <summary>Parameter value of the time of the middle control point of a quadratic Bezier curve, i.e., its x-axis value. Applies only to AV_IAMF_ANIMATION_TYPE_BEZIER Animation Type.</summary>
+    public AVRational @control_point_relative_time;
+}
+
+/// <summary>Information on how to render and mix one or more AVIAMFAudioElement to generate the final audio output, as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFMixPresentation
+{
+    public AVClass* @av_class;
+    /// <summary>Array of submixes.</summary>
+    public AVIAMFSubmix** @submixes;
+    /// <summary>Number of submixes in the presentation.</summary>
+    public uint @nb_submixes;
+    /// <summary>A dictionary of strings describing the mix in different languages. Must have the same amount of entries as every AVIAMFSubmixElement.annotations &quot;Submix element annotations&quot;, stored in the same order, and with the same key strings.</summary>
+    public AVDictionary* @annotations;
+}
+
+/// <summary>Parameters as defined in section 3.6.1 of IAMF.</summary>
+public unsafe partial struct AVIAMFParamDefinition
+{
+    public AVClass* @av_class;
+    /// <summary>Offset in bytes from the start of this struct, at which the subblocks array is located.</summary>
+    public ulong @subblocks_offset;
+    /// <summary>Size in bytes of each element in the subblocks array.</summary>
+    public ulong @subblock_size;
+    /// <summary>Number of subblocks in the array.</summary>
+    public uint @nb_subblocks;
+    /// <summary>Parameters type. Determines the type of the subblock elements.</summary>
+    public AVIAMFParamDefinitionType @type;
+    /// <summary>Identifier for the parameter substream.</summary>
+    public uint @parameter_id;
+    /// <summary>Sample rate for the parameter substream. It must not be 0.</summary>
+    public uint @parameter_rate;
+    /// <summary>The accumulated duration of all blocks in this parameter definition, in units of 1 / parameter_rate.</summary>
+    public uint @duration;
+    /// <summary>The duration of every subblock in the case where all subblocks, with the optional exception of the last subblock, have equal durations.</summary>
+    public uint @constant_subblock_duration;
+}
+
+/// <summary>Recon Gain Info Parameter Data as defined in section 3.8.3 of IAMF.</summary>
+public unsafe partial struct AVIAMFReconGain
+{
+    public AVClass* @av_class;
+    /// <summary>Duration for the given subblock, in units of 1 / AVIAMFParamDefinition.parameter_rate &quot;parameter_rate&quot;. It must not be 0.</summary>
+    public uint @subblock_duration;
+    /// <summary>Array of gain values to be applied to each channel for each layer defined in the Audio Element referencing the parent Parameter Definition. Values for layers where the AV_IAMF_LAYER_FLAG_RECON_GAIN flag is not set are undefined.</summary>
+    public byte_array6x12 @recon_gain;
+}
+
+/// <summary>Submix layout as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmix
+{
+    public AVClass* @av_class;
+    /// <summary>Array of submix elements.</summary>
+    public AVIAMFSubmixElement** @elements;
+    /// <summary>Number of elements in the submix.</summary>
+    public uint @nb_elements;
+    /// <summary>Array of submix layouts.</summary>
+    public AVIAMFSubmixLayout** @layouts;
+    /// <summary>Number of layouts in the submix.</summary>
+    public uint @nb_layouts;
+    /// <summary>Information required for post-processing the mixed audio signal to generate the audio signal for playback. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN.</summary>
+    public AVIAMFParamDefinition* @output_mix_config;
+    /// <summary>Default mix gain value to apply when there are no AVIAMFParamDefinition with output_mix_config &quot;output_mix_config&apos;s&quot; AVIAMFParamDefinition.parameter_id &quot;parameter_id&quot; available for a given audio frame.</summary>
+    public AVRational @default_mix_gain;
+}
+
+/// <summary>Submix element as defined in section 3.7 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmixElement
+{
+    public AVClass* @av_class;
+    /// <summary>The id of the Audio Element this submix element references.</summary>
+    public uint @audio_element_id;
+    /// <summary>Information required required for applying any processing to the referenced and rendered Audio Element before being summed with other processed Audio Elements. The AVIAMFParamDefinition.type &quot;type&quot; must be AV_IAMF_PARAMETER_DEFINITION_MIX_GAIN.</summary>
+    public AVIAMFParamDefinition* @element_mix_config;
+    /// <summary>Default mix gain value to apply when there are no AVIAMFParamDefinition with element_mix_config &quot;element_mix_config&apos;s&quot; AVIAMFParamDefinition.parameter_id &quot;parameter_id&quot; available for a given audio frame.</summary>
+    public AVRational @default_mix_gain;
+    /// <summary>A value that indicates whether the referenced channel-based Audio Element shall be rendered to stereo loudspeakers or spatialized with a binaural renderer when played back on headphones. If the Audio Element is not of AVIAMFAudioElement.audio_element_type &quot;type&quot; AV_IAMF_AUDIO_ELEMENT_TYPE_CHANNEL, then this field is undefined.</summary>
+    public AVIAMFHeadphonesMode @headphones_rendering_mode;
+    /// <summary>A dictionary of strings describing the submix in different languages. Must have the same amount of entries as AVIAMFMixPresentation.annotations &quot;the mix&apos;s annotations&quot;, stored in the same order, and with the same key strings.</summary>
+    public AVDictionary* @annotations;
+}
+
+/// <summary>Submix layout as defined in section 3.7.6 of IAMF.</summary>
+public unsafe partial struct AVIAMFSubmixLayout
+{
+    public AVClass* @av_class;
+    public AVIAMFSubmixLayoutType @layout_type;
+    /// <summary>Channel layout matching one of Sound Systems A to J of ITU-2051-3, plus 7.1.2ch, 3.1.2ch, and binaural. If layout_type is not AV_IAMF_SUBMIX_LAYOUT_TYPE_LOUDSPEAKERS or AV_IAMF_SUBMIX_LAYOUT_TYPE_BINAURAL, this field is undefined.</summary>
+    public AVChannelLayout @sound_system;
+    /// <summary>The program integrated loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @integrated_loudness;
+    /// <summary>The digital (sampled) peak value of the audio signal, as defined in ITU-1770-4.</summary>
+    public AVRational @digital_peak;
+    /// <summary>The true peak of the audio signal, as defined in ITU-1770-4.</summary>
+    public AVRational @true_peak;
+    /// <summary>The Dialogue loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @dialogue_anchored_loudness;
+    /// <summary>The Album loudness information, as defined in ITU-1770-4.</summary>
+    public AVRational @album_anchored_loudness;
 }
 
 public unsafe partial struct AVIndexEntry
@@ -1984,6 +2295,14 @@ public unsafe partial struct AVStreamGroupTREF
     public uint @metadata_index;
 }
 
+public unsafe partial struct AVSubsampleEncryptionInfo
+{
+    /// <summary>The number of bytes that are clear.</summary>
+    public uint @bytes_of_clear_data;
+    /// <summary>The number of bytes that are protected. If using pattern encryption, the pattern applies to only the protected bytes; if not using pattern encryption, all these bytes are encrypted.</summary>
+    public uint @bytes_of_protected_data;
+}
+
 public unsafe partial struct AVSubtitle
 {
     public ushort @format;
@@ -2525,6 +2844,19 @@ public unsafe partial struct SwsVector
     public int @length;
 }
 
+public unsafe partial struct tm
+{
+    public int @tm_sec;
+    public int @tm_min;
+    public int @tm_hour;
+    public int @tm_mday;
+    public int @tm_mon;
+    public int @tm_year;
+    public int @tm_wday;
+    public int @tm_yday;
+    public int @tm_isdst;
+}
+
 /// <summary>Context for an Audio FIFO Buffer.</summary>
 /// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVAudioFifo
@@ -2577,6 +2909,11 @@ public unsafe partial struct AVDictionary
 }
 
 /// <remarks>This struct is incomplete.</remarks>
+public unsafe partial struct AVExpr
+{
+}
+
+/// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVFilterChannelLayouts
 {
 }
@@ -2592,16 +2929,6 @@ public unsafe partial struct AVFilterPad
 }
 
 /// <remarks>This struct is incomplete.</remarks>
-public unsafe partial struct AVIAMFAudioElement
-{
-}
-
-/// <remarks>This struct is incomplete.</remarks>
-public unsafe partial struct AVIAMFMixPresentation
-{
-}
-
-/// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVIODirContext
 {
 }
@@ -2609,6 +2936,11 @@ public unsafe partial struct AVIODirContext
 /// <summary>Low-complexity tree container</summary>
 /// <remarks>This struct is incomplete.</remarks>
 public unsafe partial struct AVTreeNode
+{
+}
+
+/// <remarks>This struct is incomplete.</remarks>
+public unsafe partial struct AVTXContext
 {
 }
 

--- a/FFmpeg.AutoGen/generated/ffmpeg.functions.facade.g.cs
+++ b/FFmpeg.AutoGen/generated/ffmpeg.functions.facade.g.cs
@@ -37,6 +37,10 @@ public static unsafe partial class ffmpeg
     /// <returns>&gt;0 (read size) if OK, AVERROR_xxx otherwise, previous data will not be lost even if an error occurs.</returns>
     public static int av_append_packet(AVIOContext* @s, AVPacket* @pkt, int @size) => vectors.av_append_packet(@s, @pkt, @size);
     
+    /// <summary>Assert that floating point operations can be executed.</summary>
+    [Obsolete("without replacement")]
+    public static void av_assert0_fpu() => vectors.av_assert0_fpu();
+    
     /// <summary>Allocate an AVAudioFifo.</summary>
     /// <param name="sample_fmt">sample format</param>
     /// <param name="channels">number of channels</param>
@@ -781,6 +785,132 @@ public static unsafe partial class ffmpeg
     /// <returns>Pointer to the data of the element to copy in the newly allocated space</returns>
     public static void* av_dynarray2_add(void** @tab_ptr, int* @nb_ptr, ulong @elem_size, byte* @elem_data) => vectors.av_dynarray2_add(@tab_ptr, @nb_ptr, @elem_size, @elem_data);
     
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    public static byte* av_encryption_info_add_side_data(AVEncryptionInfo* @info, ulong* @side_data_size) => vectors.av_encryption_info_add_side_data(@info, @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure and sub-pointers to hold the given number of subsamples. This will allocate pointers for the key ID, IV, and subsample entries, set the size members, and zero-initialize the rest.</summary>
+    /// <param name="subsample_count">The number of subsamples.</param>
+    /// <param name="key_id_size">The number of bytes in the key ID, should be 16.</param>
+    /// <param name="iv_size">The number of bytes in the IV, should be 16.</param>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_alloc(uint @subsample_count, uint @key_id_size, uint @iv_size) => vectors.av_encryption_info_alloc(@subsample_count, @key_id_size, @iv_size);
+    
+    /// <summary>Allocates an AVEncryptionInfo structure with a copy of the given data.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_clone(AVEncryptionInfo* @info) => vectors.av_encryption_info_clone(@info);
+    
+    /// <summary>Frees the given encryption info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    public static void av_encryption_info_free(AVEncryptionInfo* @info) => vectors.av_encryption_info_free(@info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInfo that is contained in the given side data. The resulting object should be passed to av_encryption_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInfo* av_encryption_info_get_side_data(byte* @side_data, ulong @side_data_size) => vectors.av_encryption_info_get_side_data(@side_data, @side_data_size);
+    
+    /// <summary>Allocates and initializes side data that holds a copy of the given encryption init info. The resulting pointer should be either freed using av_free or given to av_packet_add_side_data().</summary>
+    /// <returns>The new side-data pointer, or NULL.</returns>
+    public static byte* av_encryption_init_info_add_side_data(AVEncryptionInitInfo* @info, ulong* @side_data_size) => vectors.av_encryption_init_info_add_side_data(@info, @side_data_size);
+    
+    /// <summary>Allocates an AVEncryptionInitInfo structure and sub-pointers to hold the given sizes. This will allocate pointers and set all the fields.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInitInfo* av_encryption_init_info_alloc(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size) => vectors.av_encryption_init_info_alloc(@system_id_size, @num_key_ids, @key_id_size, @data_size);
+    
+    /// <summary>Frees the given encryption init info object. This MUST NOT be used to free the side-data data pointer, that should use normal side-data methods.</summary>
+    public static void av_encryption_init_info_free(AVEncryptionInitInfo* @info) => vectors.av_encryption_init_info_free(@info);
+    
+    /// <summary>Creates a copy of the AVEncryptionInitInfo that is contained in the given side data. The resulting object should be passed to av_encryption_init_info_free() when done.</summary>
+    /// <returns>The new AVEncryptionInitInfo structure, or NULL on error.</returns>
+    public static AVEncryptionInitInfo* av_encryption_init_info_get_side_data(byte* @side_data, ulong @side_data_size) => vectors.av_encryption_init_info_get_side_data(@side_data, @side_data_size);
+    
+    /// <summary>Allocates a duplicate of the provided EXIF metadata struct. The caller owns the duplicate and must free it with av_exif_free. Returns NULL if the duplication process failed.</summary>
+    public static AVExifMetadata* av_exif_clone_ifd(AVExifMetadata* @ifd) => vectors.av_exif_clone_ifd(@ifd);
+    
+    /// <summary>Frees all resources associated with the given EXIF metadata struct. Does not free the pointer passed itself, in case it is stack-allocated. The pointer passed to this function must be freed by the caller, if it is heap-allocated. Passing NULL is permitted.</summary>
+    public static void av_exif_free(AVExifMetadata* @ifd) => vectors.av_exif_free(@ifd);
+    
+    /// <summary>Get an entry with the tagged ID from the EXIF metadata struct. A pointer to the entry will be written into *value.</summary>
+    public static int av_exif_get_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value) => vectors.av_exif_get_entry(@logctx, @ifd, @id, @flags, @value);
+    
+    /// <summary>Retrieves the tag ID associated with the provided tag string name. If the tag name is unknown, a negative number is returned. Otherwise it always fits inside a uint16_t integer.</summary>
+    public static int av_exif_get_tag_id(string @name) => vectors.av_exif_get_tag_id(@name);
+    
+    /// <summary>Retrieves the tag name associated with the provided tag ID. If the tag ID is unknown, NULL is returned.</summary>
+    public static string av_exif_get_tag_name(ushort @id) => vectors.av_exif_get_tag_name(@id);
+    
+    /// <summary>Recursively reads all tags from the IFD and stores them in the provided metadata dictionary.</summary>
+    public static int av_exif_ifd_to_dict(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata) => vectors.av_exif_ifd_to_dict(@logctx, @ifd, @metadata);
+    
+    /// <summary>Convert a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX into an orientation constant used by EXIF&apos;s orientation tag.</summary>
+    public static int av_exif_matrix_to_orientation(int* @matrix) => vectors.av_exif_matrix_to_orientation(@matrix);
+    
+    /// <summary>Convert an orientation constant used by EXIF&apos;s orientation tag into a display matrix used by AV_FRAME_DATA_DISPLAYMATRIX.</summary>
+    public static int av_exif_orientation_to_matrix(int* @matrix, int @orientation) => vectors.av_exif_orientation_to_matrix(@matrix, @orientation);
+    
+    /// <summary>Decodes the EXIF data provided in the buffer and writes it into the struct *ifd. If this function succeeds, the IFD is owned by the caller and must be cleared after use by calling av_exif_free(); If this function fails and returns a negative value, it will call av_exif_free(ifd) before returning.</summary>
+    public static int av_exif_parse_buffer(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode) => vectors.av_exif_parse_buffer(@logctx, @data, @size, @ifd, @header_mode);
+    
+    /// <summary>Remove an entry from the provided EXIF metadata struct.</summary>
+    public static int av_exif_remove_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags) => vectors.av_exif_remove_entry(@logctx, @ifd, @id, @flags);
+    
+    /// <summary>Add an entry to the provided EXIF metadata struct. If one already exists with the provided ID, it will set the existing one to have the other information provided. Otherwise, it will allocate a new entry.</summary>
+    public static int av_exif_set_entry(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value) => vectors.av_exif_set_entry(@logctx, @ifd, @id, @type, @count, @ifd_lead, @ifd_offset, @value);
+    
+    /// <summary>Allocates a buffer using av_malloc of an appropriate size and writes the EXIF data represented by ifd into that buffer.</summary>
+    public static int av_exif_write(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode) => vectors.av_exif_write(@logctx, @ifd, @buffer, @header_mode);
+    
+    /// <summary>Track the presence of user provided functions and their number of occurrences in a parsed expression.</summary>
+    /// <param name="e">the AVExpr to track user provided functions in</param>
+    /// <param name="counter">a zero-initialized array where the count of each function will be stored if you passed 5 functions with 2 arguments to av_expr_parse() then for arg=2 this will use up to 5 entries.</param>
+    /// <param name="size">size of array</param>
+    /// <param name="arg">number of arguments the counted functions have</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    public static int av_expr_count_func(AVExpr* @e, uint* @counter, int @size, int @arg) => vectors.av_expr_count_func(@e, @counter, @size, @arg);
+    
+    /// <summary>Track the presence of variables and their number of occurrences in a parsed expression</summary>
+    /// <param name="e">the AVExpr to track variables in</param>
+    /// <param name="counter">a zero-initialized array where the count of each variable will be stored</param>
+    /// <param name="size">size of array</param>
+    /// <returns>0 on success, a negative value indicates that no expression or array was passed or size was zero</returns>
+    public static int av_expr_count_vars(AVExpr* @e, uint* @counter, int @size) => vectors.av_expr_count_vars(@e, @counter, @size);
+    
+    /// <summary>Evaluate a previously parsed expression.</summary>
+    /// <param name="e">the AVExpr to evaluate</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from av_expr_parse() const_names</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <returns>the value of the expression</returns>
+    public static double av_expr_eval(AVExpr* @e, double* @const_values, void* @opaque) => vectors.av_expr_eval(@e, @const_values, @opaque);
+    
+    /// <summary>Free a parsed expression previously created with av_expr_parse().</summary>
+    public static void av_expr_free(AVExpr* @e) => vectors.av_expr_free(@e);
+    
+    /// <summary>Parse an expression.</summary>
+    /// <param name="expr">a pointer where is put an AVExpr containing the parsed value in case of successful parsing, or NULL otherwise. The pointed to AVExpr must be freed with av_expr_free() by the user when it is not needed anymore.</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_expr_parse(AVExpr** @expr, string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx) => vectors.av_expr_parse(@expr, @s, @const_names, @func1_names, @funcs1, @func2_names, @funcs2, @log_offset, @log_ctx);
+    
+    /// <summary>Parse and evaluate an expression. Note, this is significantly slower than av_expr_eval().</summary>
+    /// <param name="res">a pointer to a double where is put the result value of the expression, or NAN in case of error</param>
+    /// <param name="s">expression as a zero terminated string, for example &quot;1+2^3+5*5+sin(2/3)&quot;</param>
+    /// <param name="const_names">NULL terminated array of zero terminated strings of constant identifiers, for example {&quot;PI&quot;, &quot;E&quot;, 0}</param>
+    /// <param name="const_values">a zero terminated array of values for the identifiers from const_names</param>
+    /// <param name="func1_names">NULL terminated array of zero terminated strings of funcs1 identifiers</param>
+    /// <param name="funcs1">NULL terminated array of function pointers for functions which take 1 argument</param>
+    /// <param name="func2_names">NULL terminated array of zero terminated strings of funcs2 identifiers</param>
+    /// <param name="funcs2">NULL terminated array of function pointers for functions which take 2 arguments</param>
+    /// <param name="opaque">a pointer which will be passed to all functions from funcs1 and funcs2</param>
+    /// <param name="log_offset">log level offset, can be used to silence error messages</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_expr_parse_and_eval(double* @res, string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx) => vectors.av_expr_parse_and_eval(@res, @s, @const_names, @const_values, @func1_names, @funcs1, @func2_names, @funcs2, @opaque, @log_offset, @log_ctx);
+    
     /// <summary>Allocate a buffer, reusing the given one if large enough.</summary>
     /// <param name="ptr">Pointer to pointer to an already allocated buffer. `*ptr` will be overwritten with pointer to new buffer on success or `NULL` on failure</param>
     /// <param name="size">Pointer to the size of buffer `*ptr`. `*size` is updated to the new allocated size, in particular 0 in case of failure.</param>
@@ -847,6 +977,9 @@ public static unsafe partial class ffmpeg
     public static int av_find_best_stream(AVFormatContext* @ic, AVMediaType @type, int @wanted_stream_nb, int @related_stream, AVCodec** @decoder_ret, int @flags) => vectors.av_find_best_stream(@ic, @type, @wanted_stream_nb, @related_stream, @decoder_ret, @flags);
     
     public static int av_find_default_stream_index(AVFormatContext* @s) => vectors.av_find_default_stream_index(@s);
+    
+    /// <summary>Attempt to find a specific tag in a URL.</summary>
+    public static int av_find_info_tag(byte* @arg, int @arg_size, string @tag1, string @info) => vectors.av_find_info_tag(@arg, @arg_size, @tag1, @info);
     
     /// <summary>Find AVInputFormat based on the short name of the input format.</summary>
     public static AVInputFormat* av_find_input_format(string @short_name) => vectors.av_find_input_format(@short_name);
@@ -1065,6 +1198,12 @@ public static unsafe partial class ffmpeg
     /// <param name="flags">AV_FRAME_FILENAME_FLAGS_*</param>
     /// <returns>0 if OK, -1 on format error</returns>
     public static int av_get_frame_filename2(byte* @buf, int @buf_size, string @path, int @number, int @flags) => vectors.av_get_frame_filename2(@buf, @buf_size, @path, @number, @flags);
+    
+    /// <summary>Get the name of a color from the internal table of hard-coded named colors.</summary>
+    /// <param name="color_idx">index of the requested color, starting from 0</param>
+    /// <param name="rgb">if not NULL, will point to a 3-elements array with the color value in RGB</param>
+    /// <returns>the color name string or NULL if color_idx is not in the array</returns>
+    public static string av_get_known_color_name(int @color_idx, byte** @rgb) => vectors.av_get_known_color_name(@color_idx, @rgb);
     
     /// <summary>Return a string describing the media_type enum, NULL if media_type is unknown.</summary>
     public static string av_get_media_type_string(AVMediaType @media_type) => vectors.av_get_media_type_string(@media_type);
@@ -1308,6 +1447,45 @@ public static unsafe partial class ffmpeg
     /// <param name="flags">currently unused, should be set to zero</param>
     /// <returns>0 on success, a negative AVERROR code on failure.</returns>
     public static int av_hwframe_transfer_get_formats(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags) => vectors.av_hwframe_transfer_get_formats(@hwframe_ctx, @dir, @formats, @flags);
+    
+    /// <summary>Allocate a layer and add it to a given AVIAMFAudioElement. It is freed by av_iamf_audio_element_free() alongside the rest of the parent AVIAMFAudioElement.</summary>
+    /// <returns>a pointer to the allocated layer.</returns>
+    public static AVIAMFLayer* av_iamf_audio_element_add_layer(AVIAMFAudioElement* @audio_element) => vectors.av_iamf_audio_element_add_layer(@audio_element);
+    
+    /// <summary>Allocates a AVIAMFAudioElement, and initializes its fields with default values. No layers are allocated. Must be freed with av_iamf_audio_element_free().</summary>
+    public static AVIAMFAudioElement* av_iamf_audio_element_alloc() => vectors.av_iamf_audio_element_alloc();
+    
+    /// <summary>Free an AVIAMFAudioElement and all its contents.</summary>
+    /// <param name="audio_element">pointer to pointer to an allocated AVIAMFAudioElement. upon return, *audio_element will be set to NULL.</param>
+    public static void av_iamf_audio_element_free(AVIAMFAudioElement** @audio_element) => vectors.av_iamf_audio_element_free(@audio_element);
+    
+    public static AVClass* av_iamf_audio_element_get_class() => vectors.av_iamf_audio_element_get_class();
+    
+    /// <summary>Allocate a submix and add it to a given AVIAMFMixPresentation. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFMixPresentation.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmix* av_iamf_mix_presentation_add_submix(AVIAMFMixPresentation* @mix_presentation) => vectors.av_iamf_mix_presentation_add_submix(@mix_presentation);
+    
+    /// <summary>Allocates a AVIAMFMixPresentation, and initializes its fields with default values. No submixes are allocated. Must be freed with av_iamf_mix_presentation_free().</summary>
+    public static AVIAMFMixPresentation* av_iamf_mix_presentation_alloc() => vectors.av_iamf_mix_presentation_alloc();
+    
+    /// <summary>Free an AVIAMFMixPresentation and all its contents.</summary>
+    /// <param name="mix_presentation">pointer to pointer to an allocated AVIAMFMixPresentation. upon return, *mix_presentation will be set to NULL.</param>
+    public static void av_iamf_mix_presentation_free(AVIAMFMixPresentation** @mix_presentation) => vectors.av_iamf_mix_presentation_free(@mix_presentation);
+    
+    public static AVClass* av_iamf_mix_presentation_get_class() => vectors.av_iamf_mix_presentation_get_class();
+    
+    /// <summary>Allocates memory for AVIAMFParamDefinition, plus an array of {</summary>
+    public static AVIAMFParamDefinition* av_iamf_param_definition_alloc(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size) => vectors.av_iamf_param_definition_alloc(@type, @nb_subblocks, @size);
+    
+    public static AVClass* av_iamf_param_definition_get_class() => vectors.av_iamf_param_definition_get_class();
+    
+    /// <summary>Allocate a submix element and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmixElement* av_iamf_submix_add_element(AVIAMFSubmix* @submix) => vectors.av_iamf_submix_add_element(@submix);
+    
+    /// <summary>Allocate a submix layout and add it to a given AVIAMFSubmix. It is freed by av_iamf_mix_presentation_free() alongside the rest of the parent AVIAMFSubmix.</summary>
+    /// <returns>a pointer to the allocated submix.</returns>
+    public static AVIAMFSubmixLayout* av_iamf_submix_add_layout(AVIAMFSubmix* @submix) => vectors.av_iamf_submix_add_layout(@submix);
     
     /// <summary>Allocate an image with size w and h and pixel format pix_fmt, and fill pointers and linesizes accordingly. The allocated image buffer has to be freed by using av_freep(&amp;pointers[0]).</summary>
     /// <param name="pointers">array to be filled with the pointer for each image plane</param>
@@ -1998,9 +2176,46 @@ public static unsafe partial class ffmpeg
     /// <param name="pkt">The packet to be unreferenced.</param>
     public static void av_packet_unref(AVPacket* @pkt) => vectors.av_packet_unref(@pkt);
     
+    /// <summary>Put the RGBA values that correspond to color_string in rgba_color.</summary>
+    /// <param name="rgba_color">4-elements array of uint8_t values, where the respective red, green, blue and alpha component values are written.</param>
+    /// <param name="color_string">a string specifying a color. It can be the name of a color (case insensitive match) or a [0x|#]RRGGBB[AA] sequence, possibly followed by &quot; &quot; and a string representing the alpha component. The alpha component may be a string composed by &quot;0x&quot; followed by an hexadecimal number or a decimal number between 0.0 and 1.0, which represents the opacity value (0x00/0.0 means completely transparent, 0xff/1.0 completely opaque). If the alpha component is not specified then 0xff is assumed. The string &quot;random&quot; will result in a random color.</param>
+    /// <param name="slen">length of the initial part of color_string containing the color. It can be set to -1 if color_string is a null terminated string containing nothing else than the color.</param>
+    /// <param name="log_ctx">a pointer to an arbitrary struct of which the first field is a pointer to an AVClass struct (used for av_log()). Can be NULL.</param>
+    /// <returns>&gt;= 0 in case of success, a negative value in case of failure (for example if color_string cannot be parsed).</returns>
+    public static int av_parse_color(byte* @rgba_color, string @color_string, int @slen, void* @log_ctx) => vectors.av_parse_color(@rgba_color, @color_string, @slen, @log_ctx);
+    
     /// <summary>Parse CPU caps from a string and update the given AV_CPU_* flags based on that.</summary>
     /// <returns>negative on error.</returns>
     public static int av_parse_cpu_caps(uint* @flags, string @s) => vectors.av_parse_cpu_caps(@flags, @s);
+    
+    /// <summary>Parse str and store the parsed ratio in q.</summary>
+    /// <param name="q">pointer to the AVRational which will contain the ratio</param>
+    /// <param name="str">the string to parse: it has to be a string in the format num:den, a float number or an expression</param>
+    /// <param name="max">the maximum allowed numerator and denominator</param>
+    /// <param name="log_offset">log level offset which is applied to the log level of log_ctx</param>
+    /// <param name="log_ctx">parent logging context</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_ratio(AVRational* @q, string @str, int @max, int @log_offset, void* @log_ctx) => vectors.av_parse_ratio(@q, @str, @max, @log_offset, @log_ctx);
+    
+    /// <summary>Parse timestr and return in *time a corresponding number of microseconds.</summary>
+    /// <param name="timeval">puts here the number of microseconds corresponding to the string in timestr. If the string represents a duration, it is the number of microseconds contained in the time interval.  If the string is a date, is the number of microseconds since 1st of January, 1970 up to the time of the parsed date.  If timestr cannot be successfully parsed, set *time to INT64_MIN.</param>
+    /// <param name="timestr">a string representing a date or a duration. - If a date the syntax is:</param>
+    /// <param name="duration">flag which tells how to interpret timestr, if not zero timestr is interpreted as a duration, otherwise as a date</param>
+    /// <returns>&gt;= 0 in case of success, a negative value corresponding to an AVERROR code otherwise</returns>
+    public static int av_parse_time(long* @timeval, string @timestr, int @duration) => vectors.av_parse_time(@timeval, @timestr, @duration);
+    
+    /// <summary>Parse str and store the detected values in *rate.</summary>
+    /// <param name="rate">pointer to the AVRational which will contain the detected frame rate</param>
+    /// <param name="str">the string to parse: it has to be a string in the format rate_num / rate_den, a float number or a valid video rate abbreviation</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_video_rate(AVRational* @rate, string @str) => vectors.av_parse_video_rate(@rate, @str);
+    
+    /// <summary>Parse str and put in width_ptr and height_ptr the detected values.</summary>
+    /// <param name="width_ptr">pointer to the variable which will contain the detected width value</param>
+    /// <param name="height_ptr">pointer to the variable which will contain the detected height value</param>
+    /// <param name="str">the string to parse: it has to be a string in the format width x height or a valid video size abbreviation.</param>
+    /// <returns>&gt;= 0 on success, a negative error code otherwise</returns>
+    public static int av_parse_video_size(int* @width_ptr, int* @height_ptr, string @str) => vectors.av_parse_video_size(@width_ptr, @height_ptr, @str);
     
     public static void av_parser_close(AVCodecParserContext* @s) => vectors.av_parser_close(@s);
     
@@ -2293,6 +2508,10 @@ public static unsafe partial class ffmpeg
     /// <returns>0 on success, AVERROR(EINVAL) on overflow</returns>
     public static int av_size_mult(ulong @a, ulong @b, ulong* @r) => vectors.av_size_mult(@a, @b, @r);
     
+    /// <summary>Simplified version of strptime</summary>
+    /// <returns>a pointer to the first character not processed in this function call. In case the input string contains more characters than required by the format string the return value points right after the last consumed input character. In case the whole input string is consumed the return value points to the null byte at the end of the string. On failure NULL is returned.</returns>
+    public static byte* av_small_strptime(string @p, string @fmt, tm* @dt) => vectors.av_small_strptime(@p, @fmt, @dt);
+    
     /// <summary>Duplicate a string.</summary>
     /// <param name="s">String to be duplicated</param>
     /// <returns>Pointer to a newly-allocated string containing a copy of `s` or `NULL` if the string cannot be allocated</returns>
@@ -2318,6 +2537,11 @@ public static unsafe partial class ffmpeg
     /// <param name="len">Maximum length of the resulting string (not counting the terminating byte)</param>
     /// <returns>Pointer to a newly-allocated string containing a substring of `s` or `NULL` if the string cannot be allocated</returns>
     public static byte* av_strndup(string @s, ulong @len) => vectors.av_strndup(@s, @len);
+    
+    /// <summary>Parse the string in numstr and return its value as a double. If the string is empty, contains only whitespaces, or does not contain an initial substring that has the expected syntax for a floating-point number, no conversion is performed. In this case, returns a value of zero and the value returned in tail is the value of numstr.</summary>
+    /// <param name="numstr">a string representing a number, may contain one of the International System number postfixes, for example &apos;K&apos;, &apos;M&apos;, &apos;G&apos;. If &apos;i&apos; is appended after the postfix, powers of 2 are used instead of powers of 10. The &apos;B&apos; postfix multiplies the value by 8, and can be appended after another postfix or used alone. This allows using for example &apos;KB&apos;, &apos;MiB&apos;, &apos;G&apos; and &apos;B&apos; as postfix.</param>
+    /// <param name="tail">if non-NULL puts here the pointer to the char next after the last parsed character</param>
+    public static double av_strtod(string @numstr, byte** @tail) => vectors.av_strtod(@numstr, @tail);
     
     /// <summary>Subtract one rational from another.</summary>
     /// <param name="b">First rational</param>
@@ -2409,6 +2633,9 @@ public static unsafe partial class ffmpeg
     /// <returns>the buf parameter</returns>
     public static byte* av_timecode_make_string(AVTimecode* @tc, byte* @buf, int @framenum) => vectors.av_timecode_make_string(@tc, @buf, @framenum);
     
+    /// <summary>Convert the decomposed UTC time in tm to a time_t value.</summary>
+    public static long av_timegm(tm* @tm) => vectors.av_timegm(@tm);
+    
     public static void av_tree_destroy(AVTreeNode* @t) => vectors.av_tree_destroy(@t);
     
     /// <summary>Apply enu(opaque, &amp;elem) to all the elements in the tree in a given range.</summary>
@@ -2432,6 +2659,20 @@ public static unsafe partial class ffmpeg
     
     /// <summary>Allocate an AVTreeNode.</summary>
     public static AVTreeNode* av_tree_node_alloc() => vectors.av_tree_node_alloc();
+    
+    /// <summary>Initialize a transform context with the given configuration (i)MDCTs with an odd length are currently not supported.</summary>
+    /// <param name="ctx">the context to allocate, will be NULL on error</param>
+    /// <param name="tx">pointer to the transform function pointer to set</param>
+    /// <param name="type">type the type of transform</param>
+    /// <param name="inv">whether to do an inverse or a forward transform</param>
+    /// <param name="len">the size of the transform in samples</param>
+    /// <param name="scale">pointer to the value to scale the output if supported by type</param>
+    /// <param name="flags">a bitmask of AVTXFlags or 0</param>
+    /// <returns>0 on success, negative error code on failure</returns>
+    public static int av_tx_init(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags) => vectors.av_tx_init(@ctx, @tx, @type, @inv, @len, @scale, @flags);
+    
+    /// <summary>Frees a context and sets *ctx to NULL, does nothing when *ctx == NULL.</summary>
+    public static void av_tx_uninit(AVTXContext** @ctx) => vectors.av_tx_uninit(@ctx);
     
     /// <summary>Split a URL string into components.</summary>
     /// <param name="proto">the buffer for the protocol</param>

--- a/FFmpeg.AutoGen/generated/ffmpeg.functions.inline.g.cs
+++ b/FFmpeg.AutoGen/generated/ffmpeg.functions.inline.g.cs
@@ -192,6 +192,16 @@ public static unsafe partial class ffmpeg
     }
     // original body hash: nxiyu/BnkvF9Z/fWwpii6qfquOeLA/wdeiuxyQQxS4E=
     
+    /// <summary>Get the subblock at the specified {</summary>
+    public static void* av_iamf_param_definition_get_subblock(AVIAMFParamDefinition* @par, uint @idx)
+    {
+        // The C body asserts with av_assert0 and calls abort(); throwing carries the same
+        // meaning to a managed caller.
+        if (idx >= par->nb_subblocks) throw new IndexOutOfRangeException(nameof(idx));
+        return (byte*)par + par->subblocks_offset + idx * par->subblock_size;
+    }
+    // original body hash: px1Hq8gB6XEAsEXGs8XH6gMabrGX4d2QIZ9NUwafgjk=
+    
     /// <summary>Wrapper around av_image_copy() to workaround the limitation that the conversion from uint8_t * const * to const uint8_t * const * is not performed automatically in C.</summary>
     public static void av_image_copy2(ref byte_ptrArray4 @dst_data, in int_array4 @dst_linesizes, ref byte_ptrArray4 @src_data, in int_array4 @src_linesizes, AVPixelFormat @pix_fmt, int @width, int @height)
     {

--- a/FFmpeg.AutoGen/generated/ffmpeg.macros.g.cs
+++ b/FFmpeg.AutoGen/generated/ffmpeg.macros.g.cs
@@ -8,6 +8,11 @@ public static unsafe partial class ffmpeg
     // public static av_alias = __attribute__((may_alias));
     // public static av_alloc_size = (...);
     // public static av_always_inline = __attribute__((always_inline)) inline;
+    // public static av_assert0 = (cond) do {                                           if (!(cond)) {                                                      av_log(NULL, AV_LOG_PANIC, "Assertion %s failed at %s:%d\n",    AV_STRINGIFY(cond), __FILE__, __LINE__);                 abort();                                                        }                                                                   } while (0);
+    // public static av_assert1 = (cond)((void)(0x0));
+    // public static av_assert2 = (cond)((void)(0x0));
+    // public static av_assert2_fpu = () ((void)0);
+    // public static av_assume = (cond)(av_assert0(cond));
     /// <summary>AV_BUFFER_FLAG_READONLY = (1 &lt;&lt; 0)</summary>
     public const int AV_BUFFER_FLAG_READONLY = 0x1 << 0x0;
     /// <summary>AV_BUFFERSINK_FLAG_NO_REQUEST = 0x2</summary>
@@ -566,6 +571,8 @@ public static unsafe partial class ffmpeg
     // public static av_err2str = (errnum) av_make_error_string((char[AV_ERROR_MAX_STRING_SIZE]){0}, AV_ERROR_MAX_STRING_SIZE, errnum);
     /// <summary>AV_ERROR_MAX_STRING_SIZE = 64</summary>
     public const int AV_ERROR_MAX_STRING_SIZE = 0x40;
+    /// <summary>AV_EXIF_FLAG_RECURSIVE = 0x1 &lt;&lt; 0x0</summary>
+    public const int AV_EXIF_FLAG_RECURSIVE = 0x1 << 0x0;
     // public static av_extern_inline = inline;
     // public static av_fallthrough = __attribute__((fallthrough));
     /// <summary>AV_FDEBUG_ID3V2 = 0x0002</summary>
@@ -624,6 +631,8 @@ public static unsafe partial class ffmpeg
     public const int AV_HWACCEL_FLAG_IGNORE_LEVEL = 0x1 << 0x0;
     /// <summary>AV_HWACCEL_FLAG_UNSAFE_OUTPUT = 0x1 &lt;&lt; 0x3</summary>
     public const int AV_HWACCEL_FLAG_UNSAFE_OUTPUT = 0x1 << 0x3;
+    /// <summary>AV_IAMF_LAYER_FLAG_RECON_GAIN = 0x1 &lt;&lt; 0x0</summary>
+    public const int AV_IAMF_LAYER_FLAG_RECON_GAIN = 0x1 << 0x0;
     /// <summary>AV_INPUT_BUFFER_PADDING_SIZE = 64</summary>
     public const int AV_INPUT_BUFFER_PADDING_SIZE = 0x40;
     // public static AV_IS_INPUT_DEVICE = (category)((category)(==41) || (category)(==43) || (category)(==45));
@@ -709,6 +718,7 @@ public static unsafe partial class ffmpeg
     /// <summary>AV_OPT_SERIALIZE_SKIP_DEFAULTS = 0x00000001</summary>
     public const int AV_OPT_SERIALIZE_SKIP_DEFAULTS = 0x1;
     // public static av_parity = av_parity_c;
+    // public static av_parse_ratio_quiet = rate;
     /// <summary>AV_PARSER_PTS_NB = 0x4</summary>
     public const int AV_PARSER_PTS_NB = 0x4;
     /// <summary>AV_PIX_FMT_0BGR32 = AV_PIX_FMT_NE(0BGR, RGB0)</summary>
@@ -1220,6 +1230,7 @@ public static unsafe partial class ffmpeg
     public const int AV_TIMECODE_STR_SIZE = 0x17;
     // public static AV_TOSTRING = (s) #s;
     // public static av_uninit = (x) x=x;
+    // public static av_unreachable = (msg)                                             do {                                                                    av_log(NULL, AV_LOG_PANIC,                                          "Reached supposedly unreachable code at %s:%d: %s\n",        __FILE__, __LINE__, msg);                                    abort();                                                            } while (0);
     // public static av_unused = __attribute__((unused));
     // public static av_used = __attribute__((used));
     // public static AV_VERSION = a;

--- a/FFmpeg.AutoGen/generated/vectors.g.cs
+++ b/FFmpeg.AutoGen/generated/vectors.g.cs
@@ -37,6 +37,10 @@ public static unsafe partial class vectors
     public static av_append_packet_delegate av_append_packet;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_assert0_fpu_delegate();
+    public static av_assert0_fpu_delegate av_assert0_fpu;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVAudioFifo* av_audio_fifo_alloc_delegate(AVSampleFormat @sample_fmt, int @channels, int @nb_samples);
     public static av_audio_fifo_alloc_delegate av_audio_fifo_alloc;
     
@@ -790,6 +794,133 @@ public static unsafe partial class vectors
     public static av_dynarray2_add_delegate av_dynarray2_add;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_encryption_info_add_side_data_delegate(AVEncryptionInfo* @info, ulong* @side_data_size);
+    public static av_encryption_info_add_side_data_delegate av_encryption_info_add_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_alloc_delegate(uint @subsample_count, uint @key_id_size, uint @iv_size);
+    public static av_encryption_info_alloc_delegate av_encryption_info_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_clone_delegate(AVEncryptionInfo* @info);
+    public static av_encryption_info_clone_delegate av_encryption_info_clone;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_encryption_info_free_delegate(AVEncryptionInfo* @info);
+    public static av_encryption_info_free_delegate av_encryption_info_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInfo* av_encryption_info_get_side_data_delegate(byte* @side_data, ulong @side_data_size);
+    public static av_encryption_info_get_side_data_delegate av_encryption_info_get_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_encryption_init_info_add_side_data_delegate(AVEncryptionInitInfo* @info, ulong* @side_data_size);
+    public static av_encryption_init_info_add_side_data_delegate av_encryption_init_info_add_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInitInfo* av_encryption_init_info_alloc_delegate(uint @system_id_size, uint @num_key_ids, uint @key_id_size, uint @data_size);
+    public static av_encryption_init_info_alloc_delegate av_encryption_init_info_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_encryption_init_info_free_delegate(AVEncryptionInitInfo* @info);
+    public static av_encryption_init_info_free_delegate av_encryption_init_info_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVEncryptionInitInfo* av_encryption_init_info_get_side_data_delegate(byte* @side_data, ulong @side_data_size);
+    public static av_encryption_init_info_get_side_data_delegate av_encryption_init_info_get_side_data;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVExifMetadata* av_exif_clone_ifd_delegate(AVExifMetadata* @ifd);
+    public static av_exif_clone_ifd_delegate av_exif_clone_ifd;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_exif_free_delegate(AVExifMetadata* @ifd);
+    public static av_exif_free_delegate av_exif_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_get_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags, AVExifEntry** @value);
+    public static av_exif_get_entry_delegate av_exif_get_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_get_tag_id_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @name);
+    public static av_exif_get_tag_id_delegate av_exif_get_tag_id;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public delegate string av_exif_get_tag_name_delegate(ushort @id);
+    public static av_exif_get_tag_name_delegate av_exif_get_tag_name;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_ifd_to_dict_delegate(void* @logctx, AVExifMetadata* @ifd, AVDictionary** @metadata);
+    public static av_exif_ifd_to_dict_delegate av_exif_ifd_to_dict;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_matrix_to_orientation_delegate(int* @matrix);
+    public static av_exif_matrix_to_orientation_delegate av_exif_matrix_to_orientation;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_orientation_to_matrix_delegate(int* @matrix, int @orientation);
+    public static av_exif_orientation_to_matrix_delegate av_exif_orientation_to_matrix;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_parse_buffer_delegate(void* @logctx, byte* @data, ulong @size, AVExifMetadata* @ifd, AVExifHeaderMode @header_mode);
+    public static av_exif_parse_buffer_delegate av_exif_parse_buffer;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_remove_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, int @flags);
+    public static av_exif_remove_entry_delegate av_exif_remove_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_set_entry_delegate(void* @logctx, AVExifMetadata* @ifd, ushort @id, AVTiffDataType @type, uint @count, byte* @ifd_lead, uint @ifd_offset, void* @value);
+    public static av_exif_set_entry_delegate av_exif_set_entry;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_exif_write_delegate(void* @logctx, AVExifMetadata* @ifd, AVBufferRef** @buffer, AVExifHeaderMode @header_mode);
+    public static av_exif_write_delegate av_exif_write;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_count_func_delegate(AVExpr* @e, uint* @counter, int @size, int @arg);
+    public static av_expr_count_func_delegate av_expr_count_func;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_count_vars_delegate(AVExpr* @e, uint* @counter, int @size);
+    public static av_expr_count_vars_delegate av_expr_count_vars;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate double av_expr_eval_delegate(AVExpr* @e, double* @const_values, void* @opaque);
+    public static av_expr_eval_delegate av_expr_eval;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_expr_free_delegate(AVExpr* @e);
+    public static av_expr_free_delegate av_expr_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_parse_delegate(AVExpr** @expr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, byte** @func1_names, av_expr_parse_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_funcs2_func* @funcs2, int @log_offset, void* @log_ctx);
+    public static av_expr_parse_delegate av_expr_parse;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_expr_parse_and_eval_delegate(double* @res,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @s, byte** @const_names, double* @const_values, byte** @func1_names, av_expr_parse_and_eval_funcs1_func* @funcs1, byte** @func2_names, av_expr_parse_and_eval_funcs2_func* @funcs2, void* @opaque, int @log_offset, void* @log_ctx);
+    public static av_expr_parse_and_eval_delegate av_expr_parse_and_eval;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_fast_malloc_delegate(void* @ptr, uint* @size, ulong @min_size);
     public static av_fast_malloc_delegate av_fast_malloc;
     
@@ -848,6 +979,22 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_find_default_stream_index_delegate(AVFormatContext* @s);
     public static av_find_default_stream_index_delegate av_find_default_stream_index;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_find_info_tag_delegate(byte* @arg, int @arg_size,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @tag1,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @info);
+    public static av_find_info_tag_delegate av_find_info_tag;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVInputFormat* av_find_input_format_delegate(    
@@ -1051,6 +1198,11 @@ public static unsafe partial class vectors
     #endif
     string @path, int @number, int @flags);
     public static av_get_frame_filename2_delegate av_get_frame_filename2;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
+    public delegate string av_get_known_color_name_delegate(int @color_idx, byte** @rgb);
+    public static av_get_known_color_name_delegate av_get_known_color_name;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ConstCharPtrMarshaler))]
@@ -1296,6 +1448,54 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_hwframe_transfer_get_formats_delegate(AVBufferRef* @hwframe_ctx, AVHWFrameTransferDirection @dir, AVPixelFormat** @formats, int @flags);
     public static av_hwframe_transfer_get_formats_delegate av_hwframe_transfer_get_formats;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFLayer* av_iamf_audio_element_add_layer_delegate(AVIAMFAudioElement* @audio_element);
+    public static av_iamf_audio_element_add_layer_delegate av_iamf_audio_element_add_layer;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFAudioElement* av_iamf_audio_element_alloc_delegate();
+    public static av_iamf_audio_element_alloc_delegate av_iamf_audio_element_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_iamf_audio_element_free_delegate(AVIAMFAudioElement** @audio_element);
+    public static av_iamf_audio_element_free_delegate av_iamf_audio_element_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_audio_element_get_class_delegate();
+    public static av_iamf_audio_element_get_class_delegate av_iamf_audio_element_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmix* av_iamf_mix_presentation_add_submix_delegate(AVIAMFMixPresentation* @mix_presentation);
+    public static av_iamf_mix_presentation_add_submix_delegate av_iamf_mix_presentation_add_submix;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFMixPresentation* av_iamf_mix_presentation_alloc_delegate();
+    public static av_iamf_mix_presentation_alloc_delegate av_iamf_mix_presentation_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_iamf_mix_presentation_free_delegate(AVIAMFMixPresentation** @mix_presentation);
+    public static av_iamf_mix_presentation_free_delegate av_iamf_mix_presentation_free;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_mix_presentation_get_class_delegate();
+    public static av_iamf_mix_presentation_get_class_delegate av_iamf_mix_presentation_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFParamDefinition* av_iamf_param_definition_alloc_delegate(AVIAMFParamDefinitionType @type, uint @nb_subblocks, ulong* @size);
+    public static av_iamf_param_definition_alloc_delegate av_iamf_param_definition_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVClass* av_iamf_param_definition_get_class_delegate();
+    public static av_iamf_param_definition_get_class_delegate av_iamf_param_definition_get_class;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmixElement* av_iamf_submix_add_element_delegate(AVIAMFSubmix* @submix);
+    public static av_iamf_submix_add_element_delegate av_iamf_submix_add_element;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate AVIAMFSubmixLayout* av_iamf_submix_add_layout_delegate(AVIAMFSubmix* @submix);
+    public static av_iamf_submix_add_layout_delegate av_iamf_submix_add_layout;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_image_alloc_delegate(ref byte_ptrArray4 @pointers, ref int_array4 @linesizes, int @w, int @h, AVPixelFormat @pix_fmt, int @align);
@@ -2145,6 +2345,16 @@ public static unsafe partial class vectors
     public static av_packet_unref_delegate av_packet_unref;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_color_delegate(byte* @rgba_color,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @color_string, int @slen, void* @log_ctx);
+    public static av_parse_color_delegate av_parse_color;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int av_parse_cpu_caps_delegate(uint* @flags,     
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -2153,6 +2363,46 @@ public static unsafe partial class vectors
     #endif
     string @s);
     public static av_parse_cpu_caps_delegate av_parse_cpu_caps;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_ratio_delegate(AVRational* @q,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str, int @max, int @log_offset, void* @log_ctx);
+    public static av_parse_ratio_delegate av_parse_ratio;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_time_delegate(long* @timeval,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @timestr, int @duration);
+    public static av_parse_time_delegate av_parse_time;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_video_rate_delegate(AVRational* @rate,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    public static av_parse_video_rate_delegate av_parse_video_rate;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_parse_video_size_delegate(int* @width_ptr, int* @height_ptr,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @str);
+    public static av_parse_video_size_delegate av_parse_video_size;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_parser_close_delegate(AVCodecParserContext* @s);
@@ -2381,6 +2631,22 @@ public static unsafe partial class vectors
     public static av_size_mult_delegate av_size_mult;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte* av_small_strptime_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @p,     
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @fmt, tm* @dt);
+    public static av_small_strptime_delegate av_small_strptime;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate byte* av_strdup_delegate(    
     #if NETSTANDARD2_1_OR_GREATER || NET
     [MarshalAs(UnmanagedType.LPUTF8Str)]
@@ -2415,6 +2681,16 @@ public static unsafe partial class vectors
     #endif
     string @s, ulong @len);
     public static av_strndup_delegate av_strndup;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate double av_strtod_delegate(    
+    #if NETSTANDARD2_1_OR_GREATER || NET
+    [MarshalAs(UnmanagedType.LPUTF8Str)]
+    #else
+    [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]
+    #endif
+    string @numstr, byte** @tail);
+    public static av_strtod_delegate av_strtod;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVRational av_sub_q_delegate(AVRational @b, AVRational @c);
@@ -2471,6 +2747,10 @@ public static unsafe partial class vectors
     public static av_timecode_make_string_delegate av_timecode_make_string;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate long av_timegm_delegate(tm* @tm);
+    public static av_timegm_delegate av_timegm;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_tree_destroy_delegate(AVTreeNode* @t);
     public static av_tree_destroy_delegate av_tree_destroy;
     
@@ -2489,6 +2769,14 @@ public static unsafe partial class vectors
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate AVTreeNode* av_tree_node_alloc_delegate();
     public static av_tree_node_alloc_delegate av_tree_node_alloc;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int av_tx_init_delegate(AVTXContext** @ctx, av_tx_init_tx_func* @tx, AVTXType @type, int @inv, int @len, void* @scale, ulong @flags);
+    public static av_tx_init_delegate av_tx_init;
+    
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void av_tx_uninit_delegate(AVTXContext** @ctx);
+    public static av_tx_uninit_delegate av_tx_uninit;
     
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void av_url_split_delegate(byte* @proto, int @proto_size, byte* @authorization, int @authorization_size, byte* @hostname, int @hostname_size, int* @port_ptr, byte* @path, int @path_size,     


### PR DESCRIPTION
Two commits: a report that finds headers the parser never saw, and the first batch of what it found.

## The report

The list in `Program.Parse` names **entry points**, not files. Clang follows the includes and `ASTProcessor` takes every non-system translation unit, so a root brings its whole closure — 28 roots reached 62 headers. What a root cannot bring is a leaf that nothing includes, and most of libavutil is exactly that. Those only get noticed when somebody asks: `libavcodec/exif.h` had been unparsed since 8.1, `libavutil/raw_color_params.h` since 9.0.

It prints after processing, is silent when there is nothing to say, and splits the list by whether a header can be added at all:

```
82 header(s) under FFmpeg\include were never parsed.
  12 need headers this build does not have, so they cannot be added as they are:
    libavutil/hwcontext_cuda.h <- cuda.h
    libavutil/hwcontext_vaapi.h <- va/va.h
    libavutil/hwcontext_vulkan.h <- vulkan/vulkan.h
    ...
  70 include nothing beyond FFmpeg and the C standard library, so adding
  any of them to the list in Program.Parse would bind it:
    libavcodec/exif.h
    libavutil/parseutils.h
    ...
```

That split is the point: those twelve cannot be added without installing the SDK named beside them, which is why the list has always been curated. It is a decision, and the report keeps it visible rather than leaving it to memory.

## The seven

Not a sweep. Twenty-two of the seventy are ciphers and digests that `System.Security.Cryptography` already covers; another handful are macros or internals. These earn their place:

| header | what it brings |
|---|---|
| `libavutil/parseutils.h` | `av_parse_video_size("1280x720")`, `av_parse_video_rate`, `av_parse_color`, `av_parse_time` |
| `libavutil/tx.h` | `av_tx_init` — FFmpeg's FFT and MDCT, which .NET has no equivalent for |
| `libavutil/eval.h` | the expression evaluator, for dynamic filter values |
| `libavutil/encryption_info.h` | `AVEncryptionInfo`, for CENC streams |
| `libavutil/iamf.h` | see below |
| `libavutil/hwcontext_drm.h` | DRM PRIME, the zero-copy path on Linux |
| `libavcodec/exif.h` | EXIF metadata, new in 8.1 |

**+52 functions, +25 structs, +11 enums.**

`iamf.h` is not a nice-to-have. `avformat.h` forward-declares `AVIAMFAudioElement` and `AVIAMFMixPresentation`, so both were already generated — as **empty structs**, because the header that defines them was never parsed. Reaching them through `AVStreamGroup.params` compiled and handed you a pointer to a struct with no fields. They are complete now. The two that became incomplete in their place, `AVExpr` and `AVTXContext`, are forward-declared in FFmpeg on purpose, like `AVDictionary` and `SwrContext`.

## Two that did not make it

Both for reasons the report cannot see, which is worth recording:

- **`libavutil/fifo.h` crashes the generator.** `AVFifoCB` is a typedef to a *function type* rather than to a function pointer, so the parameter arrives as a bare `FunctionType` and `TypeHelper.GetTypeName` has no case for it. That wants a fix in the generator, not a workaround here.
- **`libavutil/timestamp.h`** is two `static inline` helpers and one export, all of which format text into a caller-supplied `char*`. The inline bodies would need hand-porting and the result would be pointless from C#, where the whole thing is `ts == long.MinValue ? "NOPTS" : ts.ToString()`.

`iamf.h` did bring one inline that needed porting — `av_iamf_param_definition_get_subblock`, whose body expands `av_assert0` into `av_log` and `abort()`. Ported to a bounds check and pointer arithmetic, and I confirmed a regeneration keeps it, which is what the body hash is there for.

## Verification

- `dotnet build -c Release` — 0 errors, 0 warnings
- `dotnet test -c Release` — 22/22
- Regeneration is idempotent, including over the hand-ported inline
- Example runs end to end: 1001 frames decoded, re-encoded and muxed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
